### PR TITLE
Fixed Versioned OData Route Constraint

### DIFF
--- a/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedODataPathRouteConstraint.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedODataPathRouteConstraint.cs
@@ -153,19 +153,25 @@
 
             var requestedVersion = request.GetRequestedApiVersion() ?? GetApiVersionFromRoutePrefix( request, route );
 
-            if ( requestedVersion == null )
+            if ( requestedVersion != null )
             {
-                if ( IsServiceDocumentOrMetadataRoute( values ) )
-                {
-                    var defaultApiVersion = request.GetConfiguration().GetDefaultApiVersion();
-                    request.SetRequestedApiVersion( defaultApiVersion );
-                    return base.Match( request, route, parameterName, values, routeDirection );
-                }
+                return ApiVersion == requestedVersion && base.Match( request, route, parameterName, values, routeDirection );
+            }
 
+            var options = request.GetApiVersioningOptions();
+
+            if ( options.DefaultApiVersion != ApiVersion )
+            {
                 return false;
             }
 
-            return ApiVersion == requestedVersion && base.Match( request, route, parameterName, values, routeDirection );
+            if ( options.AssumeDefaultVersionWhenUnspecified || IsServiceDocumentOrMetadataRoute( values ) )
+            {
+                request.SetRequestedApiVersion( ApiVersion );
+                return base.Match( request, route, parameterName, values, routeDirection );
+            }
+
+            return false;
         }
     }
 }

--- a/test/Microsoft.AspNet.OData.Versioning.Tests/Web.OData/Routing/VersionedODataPathRouteConstraintTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.Tests/Web.OData/Routing/VersionedODataPathRouteConstraintTest.cs
@@ -1,5 +1,4 @@
-﻿using Xunit;
-namespace Microsoft.Web.OData.Routing
+﻿namespace Microsoft.Web.OData.Routing
 {
     using FluentAssertions;
     using Http;


### PR DESCRIPTION
This fixes the **VersionedODataRouteConstraint**. The correct API version will now be matched to service documents, metadata, and OData controllers when using implicit API versioning.