### PR TITLE
Fix Internal Action Selection

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ActionSelectionResult.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ActionSelectionResult.cs
@@ -1,0 +1,33 @@
+﻿namespace Microsoft.Web.Http.Controllers
+{
+    using System;
+    using System.Diagnostics.Contracts;
+    using System.Web.Http.Controllers;
+
+    /// <content>
+    /// Provides additional content for the <see cref="ApiVersionActionSelector"/> class.
+    /// </content>
+    public partial class ApiVersionActionSelector
+    {
+        private sealed class ActionSelectionResult
+        {
+            internal ActionSelectionResult( HttpActionDescriptor action )
+            {
+                Contract.Requires( action != null );
+                Action = action;
+            }
+
+            internal ActionSelectionResult( Exception exception )
+            {
+                Contract.Requires( exception != null );
+                Exception = exception;
+            }
+
+            internal bool Succeeded => Exception == null;
+
+            internal HttpActionDescriptor Action { get; }
+
+            internal Exception Exception { get; }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Simulators/AdminController.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Simulators/AdminController.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Web.Http.Simulators
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Web.Http;
+
+    [ApiVersionNeutral]
+    public class AdminController : ApiController
+    {
+        [Route( "admin" )]
+        public IHttpActionResult Get() => Ok();
+
+        [HttpPost]
+        public IHttpActionResult SeedData() => Ok();
+
+        [HttpPost]
+        public IHttpActionResult MarkAsTest() => Ok();
+
+        [HttpPost]
+        [Route( "admin/inject" )]
+        public IHttpActionResult Inject() => Ok();
+    }
+}


### PR DESCRIPTION
Fixed the internal action selection process to consider both convention and attributing routing. The resolution process is now progressive rather than unioned. This avoids a smaller number of cases that cause duplicate actions to be resolves when then shouldn't be.