### PR TITLE
Fix for OData 404 Instead of 400

### DIFF
--- a/src/Microsoft.AspNet.OData.Versioning/System.Web.Http/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/System.Web.Http/HttpRequestMessageExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace System.Web.Http
+{
+    using Diagnostics.Contracts;
+    using Microsoft.OData.Core;
+    using Microsoft.Web.Http;
+    using Microsoft.Web.Http.Versioning;
+    using System.Net.Http;
+    using static System.Net.HttpStatusCode;
+
+    internal static class HttpRequestMessageExtensions
+    {
+        internal static ApiVersion GetRequestedApiVersionOrReturnBadRequest( this HttpRequestMessage request )
+        {
+            Contract.Requires( request != null );
+
+            try
+            {
+                return request.GetRequestedApiVersion();
+            }
+            catch ( AmbiguousApiVersionException ex )
+            {
+                var error = new ODataError() { ErrorCode = "AmbiguousApiVersion", Message = ex.Message };
+                throw new HttpResponseException( request.CreateResponse( BadRequest, error ) );
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/UnversionedODataPathRouteConstraint.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/UnversionedODataPathRouteConstraint.cs
@@ -1,0 +1,49 @@
+﻿namespace Microsoft.Web.OData.Routing
+{
+    using Http;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Web.Http;
+    using System.Web.Http.Routing;
+    using static System.Web.Http.Routing.HttpRouteDirection;
+
+    internal sealed class UnversionedODataPathRouteConstraint : IHttpRouteConstraint
+    {
+        private readonly ApiVersion apiVersion;
+        private readonly IEnumerable<IHttpRouteConstraint> innerConstraints;
+
+        internal UnversionedODataPathRouteConstraint( IEnumerable<IHttpRouteConstraint> innerConstraints )
+        {
+            Contract.Requires( innerConstraints != null );
+            this.innerConstraints = innerConstraints;
+        }
+
+        internal UnversionedODataPathRouteConstraint( IHttpRouteConstraint innerConstraint, ApiVersion apiVersion )
+        {
+            Contract.Requires( innerConstraint != null );
+
+            innerConstraints = new[] { innerConstraint };
+            this.apiVersion = apiVersion;
+        }
+
+        private bool MatchAnyVersion => apiVersion == null;
+
+        public bool Match( HttpRequestMessage request, IHttpRoute route, string parameterName, IDictionary<string, object> values, HttpRouteDirection routeDirection )
+        {
+            if ( routeDirection == UriGeneration )
+            {
+                return true;
+            }
+
+            if ( !MatchAnyVersion && apiVersion != request.GetRequestedApiVersion() )
+            {
+                return false;
+            }
+
+            return innerConstraints.Any( c => c.Match( request, route, parameterName, values, routeDirection ) );
+        }
+    }
+}

--- a/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedUrlHelperDecorator.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedUrlHelperDecorator.cs
@@ -1,0 +1,47 @@
+﻿namespace Microsoft.Web.OData.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Web.Http.Routing;
+
+    internal sealed class VersionedUrlHelperDecorator : UrlHelper
+    {
+        private readonly UrlHelper decorated;
+        private readonly object apiVersion;
+
+        internal VersionedUrlHelperDecorator( UrlHelper decorated, object apiVersion )
+        {
+            Contract.Requires( decorated != null );
+            Contract.Requires( apiVersion != null );
+
+            this.decorated = decorated;
+            this.apiVersion = apiVersion;
+
+            if ( decorated.Request != null )
+            {
+                Request = decorated.Request;
+            }
+        }
+
+        private void EnsureApiVersionRouteValue( IDictionary<string, object> routeValues ) => routeValues[nameof( apiVersion )] = apiVersion;
+
+        public override string Content( string path ) => decorated.Content( path );
+
+        public override string Link( string routeName, object routeValues ) => decorated.Link( routeName, routeValues );
+
+        public override string Link( string routeName, IDictionary<string, object> routeValues )
+        {
+            EnsureApiVersionRouteValue( routeValues );
+            return decorated.Link( routeName, routeValues );
+        }
+
+        public override string Route( string routeName, object routeValues ) => decorated.Route( routeName, routeValues );
+
+        public override string Route( string routeName, IDictionary<string, object> routeValues )
+        {
+            EnsureApiVersionRouteValue( routeValues );
+            return decorated.Route( routeName, routeValues );
+        }
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpResponseExceptionFactory.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpResponseExceptionFactory.cs
@@ -13,15 +13,15 @@
     {
         private static readonly string ControllerSelectorCategory = typeof( IHttpControllerSelector ).FullName;
         private readonly HttpRequestMessage request;
-        private readonly ITraceWriter traceWriter;
 
         internal HttpResponseExceptionFactory( HttpRequestMessage request )
         {
             Contract.Requires( request != null );
 
             this.request = request;
-            traceWriter = request.GetConfiguration().Services.GetTraceWriter() ?? NullTraceWriter.Instance;
         }
+
+        private ITraceWriter TraceWriter => request.GetConfiguration().Services.GetTraceWriter() ?? NullTraceWriter.Instance;
 
         [SuppressMessage( "Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Created exception cannot be disposed. Handled by the caller." )]
         internal HttpResponseException NewNotFoundOrBadRequestException( ControllerSelectionResult conventionRouteResult, ControllerSelectionResult directRouteResult ) =>
@@ -52,7 +52,7 @@
             var error = new HttpError() { Message = message, MessageDetail = messageDetail };
 
             error["Code"] = "UnsupportedApiVersion";
-            traceWriter.Info( request, ControllerSelectorCategory, message );
+            TraceWriter.Info( request, ControllerSelectorCategory, message );
 
             return new HttpResponseException( request.CreateErrorResponse( BadRequest, error ) );
         }
@@ -73,7 +73,7 @@
             var error = new HttpError() { Message = message, MessageDetail = messageDetail };
 
             error["Code"] = "InvalidApiVersion";
-            traceWriter.Info( request, ControllerSelectorCategory, message );
+            TraceWriter.Info( request, ControllerSelectorCategory, message );
 
             return new HttpResponseException( request.CreateErrorResponse( BadRequest, error ) );
         }
@@ -95,7 +95,7 @@
                 messageDetail = SR.DefaultControllerFactory_ControllerNameNotFound.FormatDefault( conventionRouteResult.ControllerName );
             }
 
-            traceWriter.Info( request, ControllerSelectorCategory, message );
+            TraceWriter.Info( request, ControllerSelectorCategory, message );
 
             return new HttpResponseException( request.CreateErrorResponse( NotFound, message, messageDetail ) );
         }

--- a/src/Microsoft.AspNet.WebApi.Versioning/Routing/ApiVersionRouteConstraint.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Routing/ApiVersionRouteConstraint.cs
@@ -2,13 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
-    using System.Linq;
     using System.Net.Http;
     using System.Web.Http;
     using System.Web.Http.Routing;
-    using static System.Web.Http.Routing.HttpRouteDirection;
     using static ApiVersion;
+    using static System.String;
+    using static System.Web.Http.Routing.HttpRouteDirection;
 
     /// <summary>
     /// Represents a route constraint for <see cref="ApiVersion">API versions</see>.
@@ -26,12 +25,13 @@
         /// <returns>True if the route constraint is matched; otherwise, false.</returns>
         public bool Match( HttpRequestMessage request, IHttpRoute route, string parameterName, IDictionary<string, object> values, HttpRouteDirection routeDirection )
         {
-            if ( routeDirection != UriResolution )
+            var value = default( string );
+
+            if ( routeDirection == UriGeneration )
             {
-                return false;
+                return !IsNullOrEmpty( parameterName ) && values.TryGetValue( parameterName, out value ) && !IsNullOrEmpty( value );
             }
 
-            var value = default( string );
             var requestedVersion = default( ApiVersion );
 
             if ( !values.TryGetValue( parameterName, out value ) || !TryParse( value, out requestedVersion ) )

--- a/test/Microsoft.AspNet.OData.Versioning.Tests/System.Web.OData/HttpConfigurationExtensionsTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.Tests/System.Web.OData/HttpConfigurationExtensionsTest.cs
@@ -85,7 +85,13 @@
             // assert
             foreach ( var route in routes )
             {
-                var constraint = (VersionedODataPathRouteConstraint) route.PathRouteConstraint;
+                var constraint = route.PathRouteConstraint as VersionedODataPathRouteConstraint;
+
+                if ( constraint == null )
+                {
+                    continue;
+                }
+
                 var apiVersion = constraint.EdmModel.GetAnnotationValue<ApiVersionAnnotation>( constraint.EdmModel ).ApiVersion;
                 var versionedRouteName = routeName + "-" + apiVersion.ToString();
 

--- a/test/Microsoft.AspNet.OData.Versioning.Tests/Web.OData/Routing/VersionedODataPathRouteConstraintTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.Tests/Web.OData/Routing/VersionedODataPathRouteConstraintTest.cs
@@ -55,7 +55,7 @@
         }
 
         [Fact]
-        public void match_should_only_evaluate_uri_resolution()
+        public void match_should_always_return_true_for_uri_resolution()
         {
             // arrange
             var request = new HttpRequestMessage();
@@ -72,7 +72,7 @@
             var result = constraint.Match( request, route, parameterName, values, routeDirection );
 
             // assert
-            result.Should().BeFalse();
+            result.Should().BeTrue();
         }
 
         [Theory]
@@ -138,27 +138,6 @@
 
             // assert
             result.Should().Be( expected );
-        }
-
-        [Theory]
-        [InlineData( "v1", "1.0" )]
-        [InlineData( "v2.0", "2.0" )]
-        public void match_should_set_requested_api_version_from_route_prefix( string routePrefix, string apiVersion )
-        {
-            // arrange
-            var requestedVersion = Parse( apiVersion );
-            var model = TestModel;
-            var request = new HttpRequestMessage( Get, $"http://localhost/{routePrefix}/Tests(1)" );
-            var values = new Dictionary<string, object>() { { "odataPath", "Tests(1)" } };
-            var constraint = NewVersionedODataPathRouteConstraint( request, model, requestedVersion, routePrefix );
-            var route = request.GetConfiguration().Routes.Single();
-
-            // act
-            var result = constraint.Match( request, route, null, values, UriResolution );
-
-            // assert
-            result.Should().BeTrue();
-            request.GetRequestedApiVersion().Should().Be( requestedVersion );
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
@@ -1,5 +1,4 @@
-﻿using Xunit;
-namespace Microsoft.Web.Http.Dispatcher
+﻿namespace Microsoft.Web.Http.Dispatcher
 {
     using Controllers;
     using FluentAssertions;
@@ -955,7 +954,6 @@ Microsoft.Web.Http.Dispatcher.ApiVersionControllerSelectorTest+AmbiguousNeutralC
         public void select_controller_should_resolve_controller_action_using_api_versioning_conventions()
         {
             // arrange
-            var supportedVersions = new[] { new ApiVersion( 1, 0 ), new ApiVersion( 2, 0 ) };
             var configuration = new HttpConfiguration();
             var request = new HttpRequestMessage( Get, "http://localhost/api/conventions?api-version=2.0" );
 
@@ -1000,7 +998,6 @@ Microsoft.Web.Http.Dispatcher.ApiVersionControllerSelectorTest+AmbiguousNeutralC
         public void select_controller_should_report_correct_api_versions_using_conventions()
         {
             // arrange
-            var supportedVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) };
             var controllerTypeResolver = new Mock<IHttpControllerTypeResolver>();
             var controllerTypes = new Collection<Type>() { typeof( ConventionsController ), typeof( Conventions2Controller ) };
             var configuration = new HttpConfiguration();


### PR DESCRIPTION
Provides the fix for returning 400 instead of 404 for OData controllers that exist, but don't match the requested API version. This change also fixes an issue discovered where URL generation fails for URL segment API versioning due to a bug in the ApiVersionRouteConstraint.