### PR TITLE
Fix for ASP.NET Core URL Generation and 404

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Routing/ApiVersionRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Routing/ApiVersionRouteConstraint.cs
@@ -3,9 +3,9 @@
     using AspNetCore.Routing;
     using Http;
     using System;
-    using System.Diagnostics.Contracts;
     using static ApiVersion;
     using static AspNetCore.Routing.RouteDirection;
+    using static System.String;
 
     /// <summary>
     /// Represents a route constraint for service <see cref="ApiVersion">API versions</see>.
@@ -24,12 +24,13 @@
         /// <returns>True if the route constraint is matched; otherwise, false.</returns>
         public bool Match( HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection )
         {
-            if ( routeDirection != IncomingRequest )
+            var value = default( string );
+
+            if ( routeDirection == UrlGeneration )
             {
-                return false;
+                return !IsNullOrEmpty( routeKey ) && values.TryGetValue( routeKey, out value ) && !IsNullOrEmpty( value );
             }
 
-            var value = default( string );
             var requestedVersion = default( ApiVersion );
 
             if ( !values.TryGetValue( routeKey, out value ) || !TryParse( value, out requestedVersion ) )

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/OrdersController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/OrdersController.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.AspNetCore.Mvc.Simulators
 {
+    using Routing;
     using System;
     using System.Threading.Tasks;
 
@@ -7,10 +8,10 @@
     [ApiVersion( "2016-06-06" )]
     public class OrdersController : Controller
     {
-        [MapToApiVersion( "2015-11-15" )]
-        public Task<IActionResult> Get_2015_11_15() => Task.FromResult<IActionResult>( Ok( "Version 2015-11-15" ) );
+        [HttpGet]
+        public Task<IActionResult> Get() => Task.FromResult<IActionResult>( Ok( "Version 2015-11-15" ) );
 
-        [Route( "orders" )]
+        [HttpGet]
         [MapToApiVersion( "2016-06-06" )]
         public Task<IActionResult> Get_2016_06_06() => Task.FromResult<IActionResult>( Ok( "Version 2016-06-06" ) );
     }


### PR DESCRIPTION
This fix correctly returns generated URLs and 400s as appropriate when using URL segment API versioning.