### PR TITLE
Fix to Return 400 Instead of 404 for Versioned Actions

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning/Controllers/AggregatedActionMapping.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Controllers/AggregatedActionMapping.cs
@@ -1,0 +1,35 @@
+﻿namespace Microsoft.Web.Http.Controllers
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Linq;
+    using System.Web.Http.Controllers;
+
+    /// <content>
+    /// Provides additional content for the <see cref="ApiVersionActionSelector"/> class.
+    /// </content>
+    public partial class ApiVersionActionSelector
+    {
+        private sealed class AggregatedActionMapping : ILookup<string, HttpActionDescriptor>
+        {
+            private readonly IReadOnlyList<ILookup<string, HttpActionDescriptor>> actionMappings;
+
+            internal AggregatedActionMapping( IReadOnlyList<ILookup<string, HttpActionDescriptor>> actionMappings )
+            {
+                Contract.Requires( actionMappings != null );
+                this.actionMappings = actionMappings;
+            }
+
+            public IEnumerable<HttpActionDescriptor> this[string key] => actionMappings.Where( am => am.Contains( key ) ).SelectMany( am => am[key] );
+
+            public int Count => actionMappings[0].Count;
+
+            public bool Contains( string key ) => actionMappings.Any( am => am.Contains( key ) );
+
+            public IEnumerator<IGrouping<string, HttpActionDescriptor>> GetEnumerator() => actionMappings[0].GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ConventionRouteControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ConventionRouteControllerSelector.cs
@@ -139,6 +139,7 @@
                 controller.SetApiVersionModel( aggregator.AllVersions );
             }
 
+            controller.SetRelatedCandidates( candidates );
             return controller;
         }
 

--- a/src/Microsoft.AspNet.WebApi.Versioning/System.Web.Http/HttpControllerDescriptorExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/System.Web.Http/HttpControllerDescriptorExtensions.cs
@@ -4,6 +4,7 @@
     using Controllers;
     using Diagnostics.CodeAnalysis;
     using Diagnostics.Contracts;
+    using Linq;
     using Microsoft;
     using Microsoft.Web.Http;
     using Microsoft.Web.Http.Versioning;
@@ -16,6 +17,7 @@
         private const string AttributeRoutedPropertyKey = "MS_IsAttributeRouted";
         private const string ApiVersionInfoKey = "MS_ApiVersionInfo";
         private const string ConventionsApiVersionInfoKey = "MS_ConventionsApiVersionInfo";
+        private const string RelatedControllerCandidatesKey = "MS_RelatedControllerCandidates";
 
         internal static bool IsAttributeRouted( this HttpControllerDescriptor controllerDescriptor )
         {
@@ -104,6 +106,12 @@
 
         internal static void SetConventionsApiVersionModel( this HttpControllerDescriptor controllerDescriptor, ApiVersionModel model ) =>
             controllerDescriptor.Properties.AddOrUpdate( ConventionsApiVersionInfoKey, model, ( key, currentModel ) => ( (ApiVersionModel) currentModel ).Aggregate( model ) );
+
+        internal static IEnumerable<HttpControllerDescriptor> GetRelatedCandidates( this HttpControllerDescriptor controllerDescriptor ) =>
+            (IEnumerable<HttpControllerDescriptor>) controllerDescriptor.Properties.GetOrAdd( RelatedControllerCandidatesKey, key => Enumerable.Empty<HttpControllerDescriptor>() );
+
+        internal static void SetRelatedCandidates( this HttpControllerDescriptor controllerDescriptor, IEnumerable<HttpControllerDescriptor> value ) =>
+            controllerDescriptor.Properties.AddOrUpdate( RelatedControllerCandidatesKey, value, ( key, oldValue ) => value );
 
         /// <summary>
         /// Gets a value indicating whether the controller is API version neutral.


### PR DESCRIPTION
This fix returns 400 for actions unsupported in some service API versions instead of returning 404.