### PR TITLE
Fixes OData route template parameter name binding

### DIFF
--- a/samples/webapi/BasicODataWebApiSample/Controllers/People2Controller.cs
+++ b/samples/webapi/BasicODataWebApiSample/Controllers/People2Controller.cs
@@ -20,7 +20,7 @@
 
         // GET ~/v3/people(1)
         // GET ~/api/people(1)?api-version=3.0
-        [ODataRoute( "({key})" )]
+        [ODataRoute( "({id})" )]
         public IHttpActionResult Get( [FromODataUri] int id, ODataQueryOptions<Person> options ) =>
             Ok( new Person() { Id = id, FirstName = "Bill", LastName = "Mei", Email = "bill.mei@somewhere.com", Phone = "555-555-5555" } );
     }

--- a/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedAttributeRoutingConvention.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedAttributeRoutingConvention.cs
@@ -76,7 +76,7 @@
                 return true;
             }
 
-            var apiVersion = Model.GetAnnotationValue<ApiVersion>( Model );
+            var apiVersion = Model.GetAnnotationValue<ApiVersionAnnotation>( Model )?.ApiVersion;
 
             return apiVersion != null && versionModel.DeclaredApiVersions.Contains( apiVersion );
         }

--- a/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedODataPathRouteConstraint.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/Web.OData/Routing/VersionedODataPathRouteConstraint.cs
@@ -67,7 +67,7 @@
 
             if ( routeDirection == UriGeneration )
             {
-                return true;
+                return base.Match( request, route, parameterName, values, routeDirection );
             }
 
             var requestedVersion = request.GetRequestedApiVersionOrReturnBadRequest();
@@ -112,7 +112,11 @@
             }
 
             var requestContext = request.GetRequestContext();
-            requestContext.Url = new VersionedUrlHelperDecorator( requestContext.Url, apiVersion );
+
+            if ( !( requestContext.Url is VersionedUrlHelperDecorator ) )
+            {
+                requestContext.Url = new VersionedUrlHelperDecorator( requestContext.Url, apiVersion );
+            }
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Versioning/project.json
+++ b/src/Microsoft.AspNet.OData.Versioning/project.json
@@ -1,5 +1,5 @@
 ﻿{
-    "version": "2.0.0-*",
+    "version": "2.0.1-*",
     "authors": [ "Microsoft" ],
     "title": "Microsoft ASP.NET Web API Versioning for OData v4.0",
     "copyright": "Copyright \u00A9 2016. Microsoft Corporation. All rights reserved.",
@@ -7,7 +7,7 @@
     "language": "en",
 
     "dependencies": {
-        "Microsoft.AspNet.OData": "5.9.1",
+        "Microsoft.AspNet.OData": "[5.9.1,6.0.0)",
         "Microsoft.AspNet.WebApi.Versioning": "2.0.0-*"
     },
 
@@ -26,7 +26,7 @@
         "summary": "Provides API versioning for RESTful services created using ASP.NET Web API and OData v4.0",
         "tags": [ "Microsoft", "AspNet", "AspNetWebAPI", "OData", "Versioning" ],
         "owners": [ "Microsoft" ],
-        "releaseNotes": "",
+        "releaseNotes": "\u2022 Fixes route template parameter name binding (Issue #40)",
         "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288890",
         "licenseUrl": "https://raw.githubusercontent.com/Microsoft/aspnet-api-versioning/master/LICENSE",
         "requireLicenseAcceptance": true,

--- a/test/Microsoft.AspNet.OData.Versioning.Tests/Web.OData/Routing/VersionedAttributeRoutingConventionTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.Tests/Web.OData/Routing/VersionedAttributeRoutingConventionTest.cs
@@ -47,8 +47,9 @@
             var model = new ODataModelBuilder().GetEdmModel();
             var controller = new HttpControllerDescriptor( new HttpConfiguration(), string.Empty, typeof( NeutralController ) );
             var convention = new VersionedAttributeRoutingConvention( model, new HttpControllerDescriptor[0] );
+            var annotation = new ApiVersionAnnotation( new ApiVersion( 1, 0 ) );
 
-            model.SetAnnotationValue( model, new ApiVersion( 1, 0 ) );
+            model.SetAnnotationValue( model, annotation );
 
             // act
             var result = convention.ShouldMapController( controller );
@@ -66,8 +67,9 @@
             var model = new ODataModelBuilder().GetEdmModel();
             var controller = new HttpControllerDescriptor( new HttpConfiguration(), string.Empty, typeof( ControllerV1 ) );
             var convention = new VersionedAttributeRoutingConvention( model, new HttpControllerDescriptor[0] );
+            var annotation = new ApiVersionAnnotation( new ApiVersion( majorVersion, 0 ) );
 
-            model.SetAnnotationValue( model, new ApiVersion( majorVersion, 0 ) );
+            model.SetAnnotationValue( model, annotation );
 
             // act
             var result = convention.ShouldMapController( controller );


### PR DESCRIPTION
- Fixes the route template parameter name used in OData route templates
- Updates the NuGet package to limit forward to support to < 6.0.0
- Minor update to sample project for consistency