### PR TITLE
Fix ArgumentNullException in ApiVersionActionSelector

### DIFF
--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/ByNamespace/Controllers/V1/AgreementsController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/ByNamespace/Controllers/V1/AgreementsController.cs
@@ -5,6 +5,7 @@
     [ApiVersion( "1.0" )]
     public class AgreementsController : Controller
     {
+        [HttpGet]
         public IActionResult Get( string accountId ) => Ok( new Agreement( GetType().FullName, accountId, HttpContext.GetRequestedApiVersion().ToString() ) );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/ByNamespace/Controllers/V2/AgreementsController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/ByNamespace/Controllers/V2/AgreementsController.cs
@@ -5,6 +5,7 @@
     [ApiVersion( "2.0" )]
     public class AgreementsController : Controller
     {
+        [HttpGet]
         public IActionResult Get( string accountId ) => Ok( new Agreement( GetType().FullName, accountId, HttpContext.GetRequestedApiVersion().ToString() ) );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/ByNamespace/Controllers/V3/AgreementsController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/ByNamespace/Controllers/V3/AgreementsController.cs
@@ -5,6 +5,7 @@
     [ApiVersion( "3.0" )]
     public class AgreementsController : Controller
     {
+        [HttpGet]
         public IActionResult Get( string accountId ) => Ok( new Agreement( GetType().FullName, accountId, HttpContext.GetRequestedApiVersion().ToString() ) );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousController.cs
@@ -6,6 +6,7 @@
     [ApiVersion( "1.0" )]
     public sealed class AmbiguousController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousNeutralController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousNeutralController.cs
@@ -7,6 +7,7 @@
     [ControllerName( "Ambiguous" )]
     public sealed class AmbiguousNeutralController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousToo2Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousToo2Controller.cs
@@ -7,6 +7,7 @@
     [ControllerName( "AmbiguousToo" )]
     public sealed class AmbiguousToo2Controller : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousTooController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AmbiguousTooController.cs
@@ -6,6 +6,7 @@
     [ApiVersion( "1.0" )]
     public sealed class AmbiguousTooController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/ApiVersionedRoute2Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/ApiVersionedRoute2Controller.cs
@@ -8,9 +8,11 @@
     [Route( "api/v{version:apiVersion}/attributed" )]
     public sealed class ApiVersionedRoute2Controller : Controller
     {
+        [HttpGet]
         [MapToApiVersion( "4.0" )]
         public Task<string> GetV4() => Task.FromResult( "Test" );
-        
+
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/ApiVersionedRouteController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/ApiVersionedRouteController.cs
@@ -9,6 +9,7 @@
     [Route( "api/v{version:apiVersion}/attributed" )]
     public sealed class ApiVersionedRouteController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguous2Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguous2Controller.cs
@@ -7,6 +7,7 @@
     [Route( "api/attributed/ambiguous" )]
     public sealed class AttributeRoutedAmbiguous2Controller : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguous3Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguous3Controller.cs
@@ -7,6 +7,7 @@
     [Route( "api/attributed/ambiguous" )]
     public sealed class AttributeRoutedAmbiguous3Controller : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguousController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguousController.cs
@@ -7,6 +7,7 @@
     [Route( "api/attributed-ambiguous" )]
     public sealed class AttributeRoutedAmbiguousController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguousNeutralController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedAmbiguousNeutralController.cs
@@ -7,6 +7,7 @@
     [Route( "api/attributed-ambiguous" )]
     public sealed class AttributeRoutedAmbiguousNeutralController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedTest2Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedTest2Controller.cs
@@ -9,8 +9,10 @@
     [Route( "api/attributed" )]
     public sealed class AttributeRoutedTest2Controller : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
 
+        [HttpGet]
         [MapToApiVersion( "3.0" )]
         public Task<string> GetV3() => Task.FromResult( "Test" );
     }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedTest4Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedTest4Controller.cs
@@ -9,6 +9,7 @@
     [Route( "api/attributed" )]
     public sealed class AttributeRoutedTest4Controller : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedTestController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedTestController.cs
@@ -6,6 +6,7 @@
     [Route( "api/attributed" )]
     public sealed class AttributeRoutedTestController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedVersionNeutralController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/AttributeRoutedVersionNeutralController.cs
@@ -7,6 +7,7 @@
     [Route( "api/attributed-neutral" )]
     public sealed class AttributeRoutedVersionNeutralController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/ConventionsController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/ConventionsController.cs
@@ -6,11 +6,13 @@
     [Route( "api/[controller]" )]
     public sealed class ConventionsController : Controller
     {
+        [HttpGet]
         public string Get() => "Test (1.0)";
 
         [HttpGet( "{id:int}" )]
         public string Get( int id ) => $"Test {id} (1.0)";
 
+        [HttpGet]
         public string GetV2() => "Test (2.0)";
 
         [HttpGet( "{id:int}" )]

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/NeutralController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/NeutralController.cs
@@ -6,6 +6,7 @@
     [ApiVersionNeutral]
     public sealed class NeutralController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/TestController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/TestController.cs
@@ -5,6 +5,7 @@
 
     public sealed class TestController : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/TestVersion2Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/TestVersion2Controller.cs
@@ -10,8 +10,10 @@
     [ControllerName( "Test" )]
     public sealed class TestVersion2Controller : Controller
     {
+        [HttpGet]
         public Task<string> Get() => Task.FromResult( "Test" );
 
+        [HttpGet]
         [MapToApiVersion( "3.0-Alpha" )]
         [MapToApiVersion( "3.0" )]
         public Task<string> Get3() => Task.FromResult( "Test" );

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/ApiVersionActionSelectorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/ApiVersionActionSelectorTest.cs
@@ -12,11 +12,13 @@
     using Simulators;
     using System;
     using System.Linq;
+    using System.Net.Http;
     using System.Reflection;
     using System.Threading.Tasks;
     using Xunit;
     using static ApiVersion;
     using static System.Environment;
+    using static System.Net.Http.HttpMethod;
     using static System.Net.HttpStatusCode;
 
     public partial class ApiVersionActionSelectorTest
@@ -167,6 +169,22 @@
             {
                 // act
                 var response = await server.Client.GetAsync( requestUri );
+
+                // assert
+                response.StatusCode.Should().Be( NotFound );
+            }
+        }
+
+        [Fact]
+        public async Task select_best_candidate_should_return_404_for_unmatched_action()
+        {
+            // arrange
+            var request = new HttpRequestMessage( Post, "api/attributed?api-version=1.0" );
+
+            using ( var server = new WebServer() )
+            {
+                // act
+                var response = await server.Client.SendAsync( request );
 
                 // assert
                 response.StatusCode.Should().Be( NotFound );


### PR DESCRIPTION
Addresses a scenario where the matched action results are null when no actions and their constraints are matched. The ApiVersionActionSelector should subsequently return null to propagate a HTTP 404 response.