### PR TITLE
Allow multiple version in constructor of ApiVersionAttribute

### DIFF
--- a/src/Common/ApiVersionAttribute.cs
+++ b/src/Common/ApiVersionAttribute.cs
@@ -20,25 +20,6 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
         /// </summary>
-        /// <param name="version">The <see cref="ApiVersion">API version</see>.</param>
-        protected ApiVersionAttribute( ApiVersion version )
-            : base( version )
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
-        /// </summary>
-        /// <param name="versions">An <see cref="Array">array</see> of API version strings.</param>
-        [CLSCompliant( false )]
-        public ApiVersionsBaseAttribute( params string[] versions )
-            : base ( versions )
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
-        /// </summary>
         /// <param name="version">The API version string.</param>
         public ApiVersionAttribute( string version )
             : base( version )
@@ -48,8 +29,26 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
         /// </summary>
+        /// <param name="versions">An <see cref="Array">array</see> of API version strings.</param>
+        [CLSCompliant( false )]
+        public ApiVersionAttribute( params string[] versions )
+            : base ( versions )
+        {
+        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
+        /// </summary>
+        /// <param name="version">The <see cref="ApiVersion">API version</see>.</param>
+        protected ApiVersionAttribute( ApiVersion version )
+            : base( version )
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
+        /// </summary>
         /// <param name="versions">An <see cref="Array">array</see> of <see cref="ApiVersion">API versions</see>.</param>
-        protected ApiVersionsBaseAttribute( params ApiVersion[] versions )
+        protected ApiVersionAttribute( params ApiVersion[] versions )
             : base ( versions )
         {
         }

--- a/src/Common/ApiVersionAttribute.cs
+++ b/src/Common/ApiVersionAttribute.cs
@@ -29,9 +29,28 @@ namespace Microsoft.AspNetCore.Mvc
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
         /// </summary>
+        /// <param name="versions">An <see cref="Array">array</see> of API version strings.</param>
+        [CLSCompliant( false )]
+        public ApiVersionsBaseAttribute( params string[] versions )
+            : base ( versions )
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
+        /// </summary>
         /// <param name="version">The API version string.</param>
         public ApiVersionAttribute( string version )
             : base( version )
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiVersionAttribute"/> class.
+        /// </summary>
+        /// <param name="versions">An <see cref="Array">array</see> of <see cref="ApiVersion">API versions</see>.</param>
+        protected ApiVersionsBaseAttribute( params ApiVersion[] versions )
+            : base ( versions )
         {
         }
 


### PR DESCRIPTION
I extended the ApiVersionAttribute to support multiple versions, this was already supported in the base class ApiVersionsBaseAttribute.