### PR TITLE
Simplify Error Response Provider

### DIFF
--- a/src/Common/Common.projitems
+++ b/src/Common/Common.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\Conventions\IApiVersionConventionT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\CurrentImplementationApiVersionSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\DefaultApiVersionSelector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Versioning\ErrorCodes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\ErrorResponseContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\HeaderApiVersionReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionNeutral.cs" />

--- a/src/Common/Versioning/ErrorCodes.cs
+++ b/src/Common/Versioning/ErrorCodes.cs
@@ -1,0 +1,34 @@
+﻿#if WEBAPI
+namespace Microsoft.Web.Http.Versioning
+#else
+namespace Microsoft.AspNetCore.Mvc.Versioning
+#endif
+{
+    using System;
+
+    /// <summary>
+    /// Defines the standard error codes returned in responses related to API versioning.
+    /// </summary>
+    public static class ErrorCodes
+    {
+        /// <summary>
+        /// Indicates that the API version requested by the client is not supported.
+        /// </summary>
+        public const string UnsupportedApiVersion = nameof( UnsupportedApiVersion );
+
+        /// <summary>
+        /// Indicates that an API version is required, but was not specified by the client.
+        /// </summary>
+        public const string ApiVersionUnspecified = nameof( ApiVersionUnspecified );
+
+        /// <summary>
+        /// Indicates that API version requested by the client is invalid or malformed.
+        /// </summary>
+        public const string InvalidApiVersion = nameof( InvalidApiVersion );
+
+        /// <summary>
+        /// Indicates that the client specified an API version multiple times and with different values.
+        /// </summary>
+        public const string AmbiguousApiVersion = nameof( AmbiguousApiVersion );
+    }
+}

--- a/src/Common/Versioning/ErrorResponseContext.cs
+++ b/src/Common/Versioning/ErrorResponseContext.cs
@@ -4,16 +4,29 @@ namespace Microsoft.Web.Http.Versioning
 namespace Microsoft.AspNetCore.Mvc.Versioning
 #endif
 {
+#if WEBAPI
+    using System.Net;
+#endif
+
     /// <summary>
     /// Represents the contextual information used when generating HTTP error responses related to API versioning.
     /// </summary>
     public partial class ErrorResponseContext
     {
         /// <summary>
+        /// Gets the associated HTTP status code.
+        /// </summary>
+        /// <value>The associated HTTP status code.</value>
+#if WEBAPI
+        public HttpStatusCode StatusCode { get; }
+#else
+        public int StatusCode { get; }
+#endif
+        /// <summary>
         /// Gets the associated error code.
         /// </summary>
         /// <value>The associated error code.</value>
-        public string Code { get; }
+        public string ErrorCode { get; }
 
         /// <summary>
         /// Gets the associated error message.

--- a/src/Common/Versioning/IErrorResponseProvider.cs
+++ b/src/Common/Versioning/IErrorResponseProvider.cs
@@ -20,17 +20,10 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
     public interface IErrorResponseProvider
     {
         /// <summary>
-        /// Creates and returns a new HTTP 400 (Bad Request) given the provided context.
+        /// Creates and returns a new error response given the provided context.
         /// </summary>
         /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
         /// <returns>The generated <see cref="IActionResult">response</see>.</returns>
-        IActionResult BadRequest( ErrorResponseContext context );
-
-        /// <summary>
-        /// Creates and returns a new HTTP 405 (Method Not Allowed) given the provided context.
-        /// </summary>
-        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
-        /// <returns>The generated <see cref="IActionResult">response</see>.</returns>
-        IActionResult MethodNotAllowed( ErrorResponseContext context );
+        IActionResult CreateResponse( ErrorResponseContext context );
     }
 }

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ApiVersionControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ApiVersionControllerSelector.cs
@@ -14,6 +14,7 @@
     using Versioning;
     using static Controllers.HttpControllerDescriptorComparer;
     using static System.StringComparer;
+    using static Versioning.ErrorCodes;
 
     /// <summary>
     /// Represents the logic for selecting a versioned controller.
@@ -164,8 +165,7 @@
             catch ( AmbiguousApiVersionException ex )
             {
                 var options = request.GetApiVersioningOptions();
-                var context = new ErrorResponseContext( request, "AmbiguousApiVersion", ex.Message, messageDetail: null );
-                throw new HttpResponseException( options.ErrorResponses.BadRequest( context ) );
+                throw new HttpResponseException( options.ErrorResponses.BadRequest( request, AmbiguousApiVersion, ex.Message ) );
             }
         }
     }

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpResponseExceptionFactory.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpResponseExceptionFactory.cs
@@ -12,6 +12,7 @@
     using static ApiVersion;
     using static System.Net.HttpStatusCode;
     using static System.String;
+    using static Versioning.ErrorCodes;
 
     sealed class HttpResponseExceptionFactory
     {
@@ -69,7 +70,6 @@
         {
             var requestedVersion = request.ApiVersionProperties().RawApiVersion;
             var message = default( string );
-            var context = default( ErrorResponseContext );
 
             if ( IsNullOrEmpty( requestedVersion ) )
             {
@@ -80,8 +80,7 @@
 
                 message = SR.ApiVersionUnspecified;
                 TraceWriter.Info( request, ControllerSelectorCategory, message );
-                context = new ErrorResponseContext( request, "ApiVersionUnspecified", message, messageDetail: null );
-                return Options.ErrorResponses.BadRequest( context );
+                return Options.ErrorResponses.BadRequest( request, ApiVersionUnspecified, message );
             }
             else if ( TryParse( requestedVersion, out var parsedVersion ) )
             {
@@ -90,11 +89,10 @@
 
             message = SR.VersionedResourceNotSupported.FormatDefault( request.RequestUri, requestedVersion );
             var messageDetail = SR.VersionedControllerNameNotFound.FormatDefault( request.RequestUri, requestedVersion );
-            context = new ErrorResponseContext( request, "InvalidApiVersion", message, messageDetail );
 
             TraceWriter.Info( request, ControllerSelectorCategory, message );
 
-            return Options.ErrorResponses.BadRequest( context );
+            return Options.ErrorResponses.BadRequest( request, InvalidApiVersion, message, messageDetail );
         }
 
         [SuppressMessage( "Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Created exception cannot be disposed. Handled by the caller." )]
@@ -105,11 +103,10 @@
 
             var message = SR.VersionedResourceNotSupported.FormatDefault( request.RequestUri, requestedVersion );
             var messageDetail = SR.VersionedControllerNameNotFound.FormatDefault( request.RequestUri, requestedVersion );
-            var context = new ErrorResponseContext( request, "UnsupportedApiVersion", message, messageDetail );
 
             TraceWriter.Info( request, ControllerSelectorCategory, message );
 
-            return Options.ErrorResponses.BadRequest( context );
+            return Options.ErrorResponses.BadRequest( request, UnsupportedApiVersion, message, messageDetail );
         }
 
         [SuppressMessage( "Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Created exception cannot be disposed. Handled by the caller." )]
@@ -141,10 +138,7 @@
             }
 
             TraceWriter.Info( request, ControllerSelectorCategory, message );
-
-            var context = new ErrorResponseContext( request, "UnsupportedApiVersion", message, messageDetail );
-
-            response = Options.ErrorResponses.MethodNotAllowed( context );
+            response = Options.ErrorResponses.MethodNotAllowed( request, UnsupportedApiVersion, message, messageDetail );
 
             if ( response.Content == null )
             {

--- a/src/Microsoft.AspNet.WebApi.Versioning/IErrorResponseProviderExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/IErrorResponseProviderExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.Web.Http
+{
+    using Microsoft.Web.Http.Versioning;
+    using System.Net;
+    using System.Net.Http;
+
+    static class IErrorResponseProviderExtensions
+    {
+        internal static HttpResponseMessage BadRequest( this IErrorResponseProvider responseProvider, HttpRequestMessage request, string code, string message, string messageDetail = null ) =>
+            responseProvider.CreateResponse( new ErrorResponseContext( request, HttpStatusCode.BadRequest, code, message, messageDetail ) );
+
+        internal static HttpResponseMessage MethodNotAllowed( this IErrorResponseProvider responseProvider, HttpRequestMessage request, string code, string message, string messageDetail = null ) =>
+            responseProvider.CreateResponse( new ErrorResponseContext( request, HttpStatusCode.MethodNotAllowed, code, message, messageDetail ) );
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DefaultErrorResponseProvider.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DefaultErrorResponseProvider.cs
@@ -1,7 +1,6 @@
 ﻿namespace Microsoft.Web.Http.Versioning
 {
     using System.Diagnostics.Contracts;
-    using System.Net;
     using System.Net.Http;
     using System.Web.Http;
     using static System.String;
@@ -12,41 +11,17 @@
     public class DefaultErrorResponseProvider : IErrorResponseProvider
     {
         /// <summary>
-        /// Creates and returns a new HTTP 400 (Bad Request) given the provided context.
+        /// Creates and returns a new error response given the provided context.
         /// </summary>
         /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
         /// <returns>The generated <see cref="HttpResponseMessage">response</see>.</returns>
-        public virtual HttpResponseMessage BadRequest( ErrorResponseContext context )
+        public virtual HttpResponseMessage CreateResponse( ErrorResponseContext context )
         {
             Arg.NotNull( context, nameof( context ) );
-            return CreateErrorResponse( context, HttpStatusCode.BadRequest );
-        }
-
-        /// <summary>
-        /// Creates and returns a new HTTP 405 (Method Not Allowed) given the provided context.
-        /// </summary>
-        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
-        /// <returns>The generated <see cref="HttpResponseMessage">response</see>.</returns>
-        public virtual HttpResponseMessage MethodNotAllowed( ErrorResponseContext context )
-        {
-            Arg.NotNull( context, nameof( context ) );
-            return CreateErrorResponse( context, HttpStatusCode.MethodNotAllowed );
-        }
-
-        static HttpResponseMessage CreateErrorResponse( ErrorResponseContext context, HttpStatusCode statusCode )
-        {
-            Contract.Requires( context != null );
-            Contract.Ensures( Contract.Result<HttpResponseMessage>() != null );
 
             var error = IsODataRequest( context ) ? CreateODataError( context ) : CreateWebApiError( context );
-            return context.Request.CreateErrorResponse( statusCode, error );
+            return context.Request.CreateErrorResponse( context.StatusCode, error );
         }
-
-        static HttpResponseMessage CreateWebApiBadRequest( ErrorResponseContext context ) =>
-            context.Request.CreateErrorResponse( HttpStatusCode.BadRequest, CreateWebApiError( context ) );
-
-        static HttpResponseMessage CreateODataBadRequest( ErrorResponseContext context ) =>
-            context.Request.CreateErrorResponse( HttpStatusCode.BadRequest, CreateODataError( context ) );
 
         static bool IsODataRequest( ErrorResponseContext context )
         {
@@ -76,9 +51,9 @@
             var error = new HttpError();
             var root = new HttpError() { ["Error"] = error };
 
-            if ( !IsNullOrEmpty( context.Code ) )
+            if ( !IsNullOrEmpty( context.ErrorCode ) )
             {
-                error["Code"] = context.Code;
+                error["Code"] = context.ErrorCode;
             }
 
             if ( !IsNullOrEmpty( context.Message ) )
@@ -101,9 +76,9 @@
 
             var error = new HttpError();
 
-            if ( !IsNullOrEmpty( context.Code ) )
+            if ( !IsNullOrEmpty( context.ErrorCode ) )
             {
-                error[HttpErrorKeys.ErrorCodeKey] = context.Code;
+                error[HttpErrorKeys.ErrorCodeKey] = context.ErrorCode;
             }
 
             if ( !IsNullOrEmpty( context.Message ) )

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DefaultErrorResponseProvider.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DefaultErrorResponseProvider.cs
@@ -18,9 +18,20 @@
         public virtual HttpResponseMessage CreateResponse( ErrorResponseContext context )
         {
             Arg.NotNull( context, nameof( context ) );
+            return context.Request.CreateErrorResponse( context.StatusCode, CreateErrorContent( context ) );
+        }
 
-            var error = IsODataRequest( context ) ? CreateODataError( context ) : CreateWebApiError( context );
-            return context.Request.CreateErrorResponse( context.StatusCode, error );
+        /// <summary>
+        /// Creates the default error content using the given context.
+        /// </summary>
+        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to create the error content.</param>
+        /// <returns>A <see cref="HttpError">HTTP error</see> representing the error content.</returns>
+        protected virtual HttpError CreateErrorContent( ErrorResponseContext context )
+        {
+            Arg.NotNull( context, nameof( context ) );
+            Contract.Ensures( Contract.Result<HttpError>() != null );
+
+            return IsODataRequest( context ) ? CreateODataError( context ) : CreateWebApiError( context );
         }
 
         static bool IsODataRequest( ErrorResponseContext context )

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/ErrorResponseContext.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/ErrorResponseContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.Web.Http.Versioning
 {
     using System;
+    using System.Net;
     using System.Net.Http;
 
     /// <content>
@@ -12,15 +13,17 @@
         /// Initializes a new instance of the <see cref="ErrorResponseContext"/> class.
         /// </summary>
         /// <param name="request">The current <see cref="HttpRequestMessage">HTTP request</see>.</param>
-        /// <param name="code">The associated error code.</param>
+        /// <param name="statusCode">The associated <see cref="HttpStatusCode">HTTP status code</see>.</param>
+        /// <param name="errorCode">The associated error code.</param>
         /// <param name="message">The error message.</param>
         /// <param name="messageDetail">The detailed error message, if any.</param>
-        public ErrorResponseContext( HttpRequestMessage request, string code, string message, string messageDetail )
+        public ErrorResponseContext( HttpRequestMessage request, HttpStatusCode statusCode, string errorCode, string message, string messageDetail )
         {
             Arg.NotNull( request, nameof( request ) );
 
             Request = request;
-            Code = code;
+            StatusCode = statusCode;
+            ErrorCode = errorCode;
             Message = message;
             MessageDetail = messageDetail;
         }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/IErrorResponseProviderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/IErrorResponseProviderExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.AspNetCore.Mvc
+{
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc.Versioning;
+    using System;
+    using static Microsoft.AspNetCore.Http.StatusCodes;
+
+    static class IErrorResponseProviderExtensions
+    {
+        internal static IActionResult BadRequest( this IErrorResponseProvider responseProvider, HttpContext context, string code, string message, string messageDetail = null ) =>
+            responseProvider.CreateResponse( new ErrorResponseContext( context.Request, Status400BadRequest, code, message, messageDetail ) );
+
+        internal static IActionResult MethodNotAllowed( this IErrorResponseProvider responseProvider, HttpContext context, string code, string message, string messageDetail = null ) =>
+            responseProvider.CreateResponse( new ErrorResponseContext( context.Request, Status405MethodNotAllowed, code, message, messageDetail ) );
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersionActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersionActionSelector.cs
@@ -16,6 +16,7 @@
     using static ApiVersion;
     using static System.Environment;
     using static System.String;
+    using static ErrorCodes;
 
     /// <summary>
     /// Represents the logic for selecting an API-versioned, action method.
@@ -192,7 +193,7 @@
             {
                 logger.LogInformation( ex.Message );
                 apiVersion = default( ApiVersion );
-                return new BadRequestHandler( Options, "AmbiguousApiVersion", ex.Message );
+                return new BadRequestHandler( Options, AmbiguousApiVersion, ex.Message );
             }
 
             return null;
@@ -224,13 +225,13 @@
 
                 if ( IsNullOrEmpty( requestedVersion ) )
                 {
-                    code = "ApiVersionUnspecified";
+                    code = ApiVersionUnspecified;
                     logger.ApiVersionUnspecified( actionNames.Value );
                     return new BadRequestHandler( Options, code, SR.ApiVersionUnspecified );
                 }
                 else if ( TryParse( requestedVersion, out parsedVersion ) )
                 {
-                    code = "UnsupportedApiVersion";
+                    code = UnsupportedApiVersion;
                     logger.ApiVersionUnmatched( parsedVersion, actionNames.Value );
 
                     if ( allowedMethods.Value.Contains( context.HttpContext.Request.Method ) )
@@ -244,7 +245,7 @@
                 }
                 else
                 {
-                    code = "InvalidApiVersion";
+                    code = InvalidApiVersion;
                     logger.ApiVersionInvalid( requestedVersion );
                     newRequestHandler = ( o, c, m ) => new BadRequestHandler( o, c, m );
                 }
@@ -252,7 +253,7 @@
             else
             {
                 requestedVersion = parsedVersion.ToString();
-                code = "UnsupportedApiVersion";
+                code = UnsupportedApiVersion;
                 logger.ApiVersionUnmatched( parsedVersion, actionNames.Value );
 
                 if ( allowedMethods.Value.Contains( context.HttpContext.Request.Method ) )

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/BadRequestHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/BadRequestHandler.cs
@@ -7,10 +7,7 @@
         internal BadRequestHandler( ApiVersioningOptions options, string code, string message )
             : base( options, code, message ) { }
 
-        protected override IActionResult CreateResult( HttpContext context )
-        {
-            var errorContext = new ErrorResponseContext( context.Request, Code, Message, messageDetail: null );
-            return Options.ErrorResponses.BadRequest( errorContext );
-        }
+        protected override IActionResult CreateResult( HttpContext context ) =>
+            Options.ErrorResponses.BadRequest( context, Code, Message );
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/DefaultErrorResponseProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/DefaultErrorResponseProvider.cs
@@ -4,7 +4,6 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.Contracts;
-    using static Http.StatusCodes;
     using static System.String;
 
     /// <summary>
@@ -14,25 +13,14 @@
     public class DefaultErrorResponseProvider : IErrorResponseProvider
     {
         /// <summary>
-        /// Creates and returns a new HTTP 400 (Bad Request) given the provided context.
+        /// Creates and returns a new error response given the provided context.
         /// </summary>
         /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
         /// <returns>The generated <see cref="IActionResult">response</see>.</returns>
-        public virtual IActionResult BadRequest( ErrorResponseContext context )
+        public virtual IActionResult CreateResponse( ErrorResponseContext context )
         {
             Arg.NotNull( context, nameof( context ) );
-            return new BadRequestObjectResult( CreateErrorContent( context ) );
-        }
-
-        /// <summary>
-        /// Creates and returns a new HTTP 405 (Method Not Allowed) given the provided context.
-        /// </summary>
-        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
-        /// <returns>The generated <see cref="IActionResult">response</see>.</returns>
-        public virtual IActionResult MethodNotAllowed( ErrorResponseContext context )
-        {
-            Arg.NotNull( context, nameof( context ) );
-            return new ObjectResult( CreateErrorContent( context ) ) { StatusCode = Status405MethodNotAllowed };
+            return new ObjectResult( CreateErrorContent( context ) ) { StatusCode = context.StatusCode };
         }
 
         static object CreateErrorContent( ErrorResponseContext context )
@@ -43,9 +31,9 @@
             var error = new Dictionary<string, object>();
             var root = new Dictionary<string, object>() { ["Error"] = error };
 
-            if ( !IsNullOrEmpty( context.Code ) )
+            if ( !IsNullOrEmpty( context.ErrorCode ) )
             {
-                error["Code"] = context.Code;
+                error["Code"] = context.ErrorCode;
             }
 
             if ( !IsNullOrEmpty( context.Message ) )

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/DefaultErrorResponseProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/DefaultErrorResponseProvider.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Creates and returns a new error response given the provided context.
         /// </summary>
-        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate response.</param>
+        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to generate the response.</param>
         /// <returns>The generated <see cref="IActionResult">response</see>.</returns>
         public virtual IActionResult CreateResponse( ErrorResponseContext context )
         {
@@ -23,13 +23,20 @@
             return new ObjectResult( CreateErrorContent( context ) ) { StatusCode = context.StatusCode };
         }
 
-        static object CreateErrorContent( ErrorResponseContext context )
+        /// <summary>
+        /// Creates the default error content using the given context.
+        /// </summary>
+        /// <param name="context">The <see cref="ErrorResponseContext">error context</see> used to create the error content.</param>
+        /// <returns>A <see cref="IDictionary{TKey, TValue}">collection</see> of <see cref="KeyValuePair{TKey, TValue}">key/value pairs</see>
+        /// representing the error content.</returns>
+        protected virtual IDictionary<string, object> CreateErrorContent( ErrorResponseContext context )
         {
-            Contract.Requires( context != null );
-            Contract.Ensures( Contract.Result<object>() != null );
+            Arg.NotNull( context, nameof( context ) );
+            Contract.Ensures( Contract.Result<IDictionary<string, object>>() != null );
 
-            var error = new Dictionary<string, object>();
-            var root = new Dictionary<string, object>() { ["Error"] = error };
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            var error = new Dictionary<string, object>( comparer );
+            var root = new Dictionary<string, object>( comparer ) { ["Error"] = error };
 
             if ( !IsNullOrEmpty( context.ErrorCode ) )
             {
@@ -47,7 +54,7 @@
 
                 if ( environment?.IsDevelopment() == true )
                 {
-                    error["InnerError"] = new Dictionary<string, object>() { ["Message"] = context.MessageDetail };
+                    error["InnerError"] = new Dictionary<string, object>( comparer ) { ["Message"] = context.MessageDetail };
                 }
             }
 

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ErrorResponseContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ErrorResponseContext.cs
@@ -12,16 +12,18 @@
         /// Initializes a new instance of the <see cref="ErrorResponseContext"/> class.
         /// </summary>
         /// <param name="request">The current <see cref="HttpRequest">HTTP request</see>.</param>
-        /// <param name="code">The associated error code.</param>
+        /// <param name="statusCode">The associated HTTP status code.</param>
+        /// <param name="errorCode">The associated error code.</param>
         /// <param name="message">The error message.</param>
         /// <param name="messageDetail">The detailed error message, if any.</param>
         [CLSCompliant( false )]
-        public ErrorResponseContext( HttpRequest request, string code, string message, string messageDetail )
+        public ErrorResponseContext( HttpRequest request, int statusCode, string errorCode, string message, string messageDetail )
         {
             Arg.NotNull( request, nameof( request ) );
 
             Request = request;
-            Code = code;
+            StatusCode = statusCode;
+            ErrorCode = errorCode;
             Message = message;
             MessageDetail = messageDetail;
         }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/MethodNotAllowedHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/MethodNotAllowedHandler.cs
@@ -19,8 +19,7 @@
 
         protected override IActionResult CreateResult( HttpContext context )
         {
-            var errorContext = new ErrorResponseContext( context.Request, Code, Message, messageDetail: null );
-            var result = Options.ErrorResponses.MethodNotAllowed( errorContext );
+            var result = Options.ErrorResponses.MethodNotAllowed( context, Code, Message );
             return allowedMethods.Length == 0 ? result : new AllowHeaderResult( result, allowedMethods );
         }
 


### PR DESCRIPTION
Refactors and simplifies the IErrorResponseProvider. The ErrorResponseContext now provides the default HTTP status code. An ErrorCodes type is now provided with the set of constant error codes returned in error response. These two pieces of information should allow customizations to error responses such as 404 and 406 depending on the API versioning method.