### PR TITLE
Add header versioning sample with js inject and reuse controller actions

### DIFF
--- a/ApiVersioningWithSamples.sln
+++ b/ApiVersioningWithSamples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.3
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4D5F5F21-0CB7-4B4E-A42F-732BD4AFD0FF}"
 EndProject
@@ -74,11 +74,11 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Test.Common", "test\Test.Co
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Acceptance.Test.Shared", "test\Acceptance.Test.Shared\Acceptance.Test.Shared.shproj", "{6CDFB878-2642-4F98-AE35-621BAC581181}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ByNamespaceSample", "samples\aspnetcore\ByNamespaceSample\ByNamespaceSample.csproj", "{83B21A5B-0779-4391-9700-58AEFEBFA615}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ByNamespaceSample", "samples\aspnetcore\ByNamespaceSample\ByNamespaceSample.csproj", "{83B21A5B-0779-4391-9700-58AEFEBFA615}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.WebApi.Versioning.ApiExplorer", "src\Microsoft.AspNet.WebApi.Versioning.ApiExplorer\Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj", "{91E1F0B5-905D-446C-A2DD-4C1EDABFAF6C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNet.WebApi.Versioning.ApiExplorer", "src\Microsoft.AspNet.WebApi.Versioning.ApiExplorer\Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj", "{91E1F0B5-905D-446C-A2DD-4C1EDABFAF6C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests", "test\Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests\Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests.csproj", "{19A2C130-46B4-4CA3-B655-B7547BC414AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests", "test\Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests\Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests.csproj", "{19A2C130-46B4-4CA3-B655-B7547BC414AC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer", "src\Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer\Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.csproj", "{F7784C3A-5569-4590-AE28-B721C0426045}"
 EndProject
@@ -90,9 +90,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SwaggerWebApiSample", "samp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SwaggerODataWebApiSample", "samples\webapi\SwaggerODataWebApiSample\SwaggerODataWebApiSample.csproj", "{F3986F7B-AF76-43D1-A44F-303023A08CD3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.OData.Versioning.ApiExplorer", "src\Microsoft.AspNet.OData.Versioning.ApiExplorer\Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj", "{1B255310-A2B7-437F-804F-6E1D8C940A17}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNet.OData.Versioning.ApiExplorer", "src\Microsoft.AspNet.OData.Versioning.ApiExplorer\Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj", "{1B255310-A2B7-437F-804F-6E1D8C940A17}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests", "test\Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests\Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests.csproj", "{3B7E0FEF-8019-4A17-A55F-A6FA378DA856}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests", "test\Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests\Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests.csproj", "{3B7E0FEF-8019-4A17-A55F-A6FA378DA856}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SwaggerSampleHeader", "samples\aspnetcore\SwaggerSampleHeader\SwaggerSampleHeader.csproj", "{EF7A7C26-D5F1-4911-AB2F-8A7AB7981BB3}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -210,6 +212,10 @@ Global
 		{3B7E0FEF-8019-4A17-A55F-A6FA378DA856}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B7E0FEF-8019-4A17-A55F-A6FA378DA856}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B7E0FEF-8019-4A17-A55F-A6FA378DA856}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF7A7C26-D5F1-4911-AB2F-8A7AB7981BB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF7A7C26-D5F1-4911-AB2F-8A7AB7981BB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF7A7C26-D5F1-4911-AB2F-8A7AB7981BB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF7A7C26-D5F1-4911-AB2F-8A7AB7981BB3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -247,5 +253,6 @@ Global
 		{F3986F7B-AF76-43D1-A44F-303023A08CD3} = {F446ED94-368F-4F67-913B-16E82CA80DFC}
 		{1B255310-A2B7-437F-804F-6E1D8C940A17} = {4D5F5F21-0CB7-4B4E-A42F-732BD4AFD0FF}
 		{3B7E0FEF-8019-4A17-A55F-A6FA378DA856} = {0987757E-4D09-4523-B9C9-65B1E8832AA1}
+		{EF7A7C26-D5F1-4911-AB2F-8A7AB7981BB3} = {900DD210-8500-4D89-A05D-C9526935A719}
 	EndGlobalSection
 EndGlobal

--- a/samples/aspnetcore/SwaggerSampleHeader/Program.cs
+++ b/samples/aspnetcore/SwaggerSampleHeader/Program.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+namespace SwaggerSampleHeader
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .UseApplicationInsights()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/Properties/launchSettings.json
+++ b/samples/aspnetcore/SwaggerSampleHeader/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:49861/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SwaggerSampleHeader": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:49862"
+    }
+  }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/Startup.cs
+++ b/samples/aspnetcore/SwaggerSampleHeader/Startup.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc.Versioning;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.PlatformAbstractions;
+using System.Reflection;
+using System.IO;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace SwaggerSampleHeader
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvcCore().AddJsonFormatters().AddVersionedApiExplorer();
+            services.AddMvc();
+            services.AddApiVersioning(o =>
+            {
+                o.ReportApiVersions = true;
+                o.ApiVersionReader = new HeaderApiVersionReader("api-version");
+            });
+            services.AddSwaggerGen(options =>
+            {
+                var provider = services.BuildServiceProvider().GetRequiredService<IApiVersionDescriptionProvider>();
+
+                foreach (var description in provider.ApiVersionDescriptions)
+                {
+                    options.SwaggerDoc(description.GroupName, CreateInfoForApiVersion(description));
+                }
+
+                var basePath = PlatformServices.Default.Application.ApplicationBasePath;
+                var fileName = typeof(Startup).GetTypeInfo().Assembly.GetName().Name + ".xml";
+                options.IncludeXmlComments(Path.Combine(basePath, fileName));
+                options.CustomSchemaIds(t => t.FullName);
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole();
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app
+                .UseStaticFiles()
+                .UseMvc()
+                .UseSwagger()
+                .UseSwaggerUI(
+                    options =>
+                    {
+                        var provider = app.ApplicationServices.GetRequiredService<IApiVersionDescriptionProvider>();
+
+                        foreach (var description in provider.ApiVersionDescriptions)
+                        {
+                            options.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", $"v{description.ApiVersion}");
+                        }
+
+                        options.InjectOnCompleteJavaScript("/SwaggerVersionHeader.js");
+                    });
+        }
+
+        private Info CreateInfoForApiVersion(ApiVersionDescription description)
+        {
+            var apiInformation = new Info()
+            {
+                Contact = new Contact() { Email = "luis_ruiz_pavon@mail.com" },
+                Version = description.ApiVersion.ToString(),
+                Title = $"Swagger sample versioninig {description.ApiVersion}",
+                Description = "A sample application using Swagger & Api Versioning",
+                TermsOfService = "bla bla bla",
+                License = new License() { Name = "MIT", Url = "https://opensource.org/licenses/MIT" }
+            };
+
+            if (description.IsDeprecated)
+            {
+                apiInformation.Description += " THIS API VERSION HAS BEEN DEPRECATED";
+            }
+
+            return apiInformation;
+        }
+    }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/SwaggerSampleHeader.csproj
+++ b/samples/aspnetcore/SwaggerSampleHeader/SwaggerSampleHeader.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netcoreapp1.1\SwaggerSampleHeader.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="wwwroot\SwaggerVersionHeader.js">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.AspNetCore.Mvc.Versioning\Microsoft.AspNetCore.Mvc.Versioning.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer\Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="1.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/aspnetcore/SwaggerSampleHeader/V1/Controllers/CustomersController.cs
+++ b/samples/aspnetcore/SwaggerSampleHeader/V1/Controllers/CustomersController.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SwaggerSampleHeader.V1.Models;
+
+namespace SwaggerSampleHeader.V1.Controllers
+{
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    [Route("api/[controller]")]
+    public class CustomersController : Controller
+    {
+        [HttpGet("{id:int}")]
+        [MapToApiVersion("1.0")]
+        [ProducesResponseType(typeof(Customer), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult Get(int id)
+        {
+            return Ok(new Customer() { Id = 1, FullName = "Luis Ruiz" });
+        }
+
+        [HttpDelete("{id:int}")]
+        [ProducesResponseType(typeof(Customer), 204)]
+        [ProducesResponseType(404)]
+        public IActionResult Delete(int id)
+        {
+            return NoContent();
+        }
+    }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/V1/Models/Customer.cs
+++ b/samples/aspnetcore/SwaggerSampleHeader/V1/Models/Customer.cs
@@ -1,0 +1,8 @@
+﻿namespace SwaggerSampleHeader.V1.Models
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string FullName { get; set; }
+    }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/V2/Controllers/CustomersController.cs
+++ b/samples/aspnetcore/SwaggerSampleHeader/V2/Controllers/CustomersController.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SwaggerSampleHeader.V2.Models;
+
+namespace SwaggerSampleHeader.V2.Controllers
+{
+    [ApiVersion("2.0")]
+    [Route("api/[controller]")]
+    public class CustomersController : Controller
+    {
+        [HttpGet("{id:int}")]
+        [MapToApiVersion("2.0")]
+        [ProducesResponseType(typeof(Customer), 200)]
+        [ProducesResponseType(404)]
+        public IActionResult Get(int id)
+        {
+            return Ok(new Customer() { Id = 1, FirstName = "Luis", LastName= "Ruiz" });
+        }
+    }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/V2/Models/Customer.cs
+++ b/samples/aspnetcore/SwaggerSampleHeader/V2/Models/Customer.cs
@@ -1,0 +1,9 @@
+﻿namespace SwaggerSampleHeader.V2.Models
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/samples/aspnetcore/SwaggerSampleHeader/wwwroot/SwaggerVersionHeader.js
+++ b/samples/aspnetcore/SwaggerSampleHeader/wwwroot/SwaggerVersionHeader.js
@@ -1,0 +1,4 @@
+﻿$(function () {
+    window.version = $("#select_document option:selected").text().substring(1);
+    window.swaggerUi.api.clientAuthorizations.add("api-version", new SwaggerClient.ApiKeyAuthorization('api-version', window.version, 'header'));
+});


### PR DESCRIPTION
Hi,

I've added a new sample using version header (api-version) and I've added and inject a js file to send the header when you change the version selector in swagger ui.

Also, I've added two version of the same controllers but in my case I'm reusing the actions that do not change between versions. The new versioned controller only add the controller actions that have breaking changes between versions.

Regards!