### PR TITLE
API Explorer Fixes (Beta 1)

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/CollectionExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/CollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace Microsoft.Web.Http
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+
+    static class CollectionExtensions
+    {
+        internal static int IndexOf<TItem>( this IEnumerable<TItem> sequence, TItem item, IEqualityComparer<TItem> comparer )
+        {
+            Contract.Requires( sequence != null );
+            Contract.Requires( comparer != null );
+            Contract.Ensures( Contract.Result<int>() >= -1 );
+
+            var index = 0;
+
+            foreach ( var element in sequence )
+            {
+                if ( comparer.Equals( element, item ) )
+                {
+                    return index;
+                }
+
+                index++;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/TestConfigurations.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/TestConfigurations.cs
@@ -38,6 +38,7 @@
                                        .HasApiVersion( 2, 0 )
                                        .HasDeprecatedApiVersion( 3, 0, "beta" )
                                        .HasApiVersion( 3, 0 )
+                                       .Action( c => c.GetV3() ).MapToApiVersion( 3, 0 )
                                        .Action( c => c.Post( default( ClassWithId ) ) ).MapToApiVersion( 3, 0 );
                     options.Conventions.Controller<Values3Controller>()
                                        .HasApiVersion( 4, 0 )

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/VersionedApiExplorerTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/VersionedApiExplorerTest.cs
@@ -356,21 +356,24 @@
                         ID = $"GET{relativePaths[0]}",
                         HttpMethod = Get,
                         RelativePath = relativePaths[0],
-                        Version = apiVersion
+                        Version = apiVersion,
+                        ActionDescriptor = new { ActionName = "GetV3" }
                     },
                     new
                     {
                         ID = $"GET{relativePaths[1]}",
                         HttpMethod = Get,
                         RelativePath = relativePaths[1],
-                        Version = apiVersion
+                        Version = apiVersion,
+                        ActionDescriptor = new { ActionName = "Get" }
                     },
                     new
                     {
                         ID = $"POST{relativePaths[2]}",
                         HttpMethod = Post,
                         RelativePath = relativePaths[2],
-                        Version = apiVersion
+                        Version = apiVersion,
+                        ActionDescriptor = new { ActionName = "Post" }
                     }
                 },
                 options => options.ExcludingMissingMembers() );

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Simulators/AttributeValues2Controller.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Simulators/AttributeValues2Controller.cs
@@ -1,6 +1,8 @@
 ﻿namespace Microsoft.Web.Http.Description.Simulators
 {
     using Microsoft.Web.Http.Description.Models;
+    using System;
+    using System.Web.Http.Description;
     using System.Web.Http;
 
     [ApiVersion( "2.0" )]
@@ -10,7 +12,12 @@
     public class AttributeValues2Controller : ApiController
     {
         [Route]
-        public IHttpActionResult Get() => Ok();
+        public string Get() => "Test";
+
+        [Route]
+        [MapToApiVersion( "3.0" )]
+        [ResponseType( typeof( string ) )]
+        public IHttpActionResult GetV3() => Ok( "Test" );
 
         [Route( "{id:int}" )]
         public IHttpActionResult Get( int id ) => Ok();

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Simulators/Values2Controller.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Simulators/Values2Controller.cs
@@ -2,11 +2,15 @@
 {
     using Microsoft.Web.Http.Description.Models;
     using System.Web.Http;
+    using System.Web.Http.Description;
 
     [ControllerName( "Values" )]
     public class Values2Controller : ApiController
     {
-        public IHttpActionResult Get() => Ok();
+        public string Get() => "Test";
+
+        [ResponseType( typeof( string ) )]
+        public IHttpActionResult GetV3() => Ok( "Test" );
 
         public IHttpActionResult Get( int id ) => Ok();
 

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/DefaultApiVersionDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/DefaultApiVersionDescriptionProviderTest.cs
@@ -5,6 +5,7 @@
     using Microsoft.AspNetCore.Mvc.ApplicationModels;
     using Microsoft.AspNetCore.Mvc.Infrastructure;
     using Microsoft.AspNetCore.Mvc.Versioning;
+    using Microsoft.Extensions.Options;
     using Moq;
     using System.Reflection;
     using Xunit;
@@ -18,7 +19,8 @@
             // arrange
             var actionProvider = new TestActionDescriptorCollectionProvider();
             var groupNameFormatter = new DefaultApiVersionGroupNameFormatter();
-            var descriptionProvider = new DefaultApiVersionDescriptionProvider( actionProvider, groupNameFormatter );
+            var apiVersioningOptions = new OptionsWrapper<ApiVersioningOptions>( new ApiVersioningOptions() );
+            var descriptionProvider = new DefaultApiVersionDescriptionProvider( actionProvider, groupNameFormatter, apiVersioningOptions );
 
             // act
             var descriptions = descriptionProvider.ApiVersionDescriptions;
@@ -40,7 +42,8 @@
             // arrange
             var provider = new DefaultApiVersionDescriptionProvider(
                 new Mock<IActionDescriptorCollectionProvider>().Object,
-                new Mock<IApiVersionGroupNameFormatter>().Object );
+                new Mock<IApiVersionGroupNameFormatter>().Object,
+                new OptionsWrapper<ApiVersioningOptions>( new ApiVersioningOptions() ) );
             var action = new ActionDescriptor();
 
             // act
@@ -56,7 +59,8 @@
             // arrange
             var provider = new DefaultApiVersionDescriptionProvider(
                 new Mock<IActionDescriptorCollectionProvider>().Object,
-                new Mock<IApiVersionGroupNameFormatter>().Object );
+                new Mock<IApiVersionGroupNameFormatter>().Object,
+                new OptionsWrapper<ApiVersioningOptions>( new ApiVersioningOptions() ) );
             var action = new ActionDescriptor();
             var controller = new ControllerModel( typeof( Controller ).GetTypeInfo(), new object[0] );
 
@@ -78,7 +82,8 @@
             // arrange
             var provider = new DefaultApiVersionDescriptionProvider(
                 new Mock<IActionDescriptorCollectionProvider>().Object,
-                new Mock<IApiVersionGroupNameFormatter>().Object );
+                new Mock<IApiVersionGroupNameFormatter>().Object,
+                new OptionsWrapper<ApiVersioningOptions>( new ApiVersioningOptions() ) );
             var action = new ActionDescriptor();
             var controller = new ControllerModel( typeof( Controller ).GetTypeInfo(), new object[0] );
             var model = new ApiVersionModel(

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/VersionedApiDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/VersionedApiDescriptionProviderTest.cs
@@ -3,6 +3,8 @@
     using FluentAssertions;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
     using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+    using Microsoft.AspNetCore.Mvc.Versioning;
+    using Microsoft.Extensions.Options;
     using Moq;
     using System.Collections.Generic;
     using Xunit;
@@ -17,7 +19,8 @@
             var context = new ApiDescriptionProviderContext( actionProvider.ActionDescriptors.Items );
             var groupNameFormatter = new DefaultApiVersionGroupNameFormatter();
             var modelMetadataProvider = NewModelMetadataProvider();
-            var apiExplorer = new VersionedApiDescriptionProvider( groupNameFormatter, modelMetadataProvider );
+            var apiVersioningOptions = new OptionsWrapper<ApiVersioningOptions>( new ApiVersioningOptions() );
+            var apiExplorer = new VersionedApiDescriptionProvider( groupNameFormatter, modelMetadataProvider, apiVersioningOptions );
 
             foreach ( var action in context.Actions )
             {


### PR DESCRIPTION
This PR fixes:

* Wrong HttpActionDescriptor is discovered in the ApiDescription when actions have the same name and API versions are interleaved (#117)
* Discovery of API version-neutral controllers and actions (#118)
* The default API version is discovered if no other API versions are found