### PR TITLE
Fix API Versioning When ITraceWriter Is Used

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ActionSelectorCacheItem.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ActionSelectorCacheItem.cs
@@ -377,8 +377,9 @@
                 foreach ( var candidate in candidatesFound )
                 {
                     var descriptor = candidate.ActionDescriptor;
+                    var candidateControllerDescriptor = Decorator.GetInner( descriptor.ControllerDescriptor );
 
-                    if ( descriptor.ControllerDescriptor == controllerDescriptor && IsSubset( actionParameterNames[descriptor], candidate.CombinedParameterNames ) )
+                    if ( candidateControllerDescriptor == controllerDescriptor && IsSubset( actionParameterNames[descriptor], candidate.CombinedParameterNames ) )
                     {
                         matches.Add( candidate );
                     }

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/AcceptanceTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/AcceptanceTest.cs
@@ -6,6 +6,7 @@
     using System.Net.Http.Headers;
     using System.Web.Http;
     using System.Web.Http.Dispatcher;
+    using System.Web.Http.Tracing;
     using Xunit;
     using static System.String;
     using static System.Web.Http.IncludeErrorDetailPolicy;
@@ -17,6 +18,7 @@
         {
             Configuration.IncludeErrorDetailPolicy = Always;
             Configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), FilteredControllerTypes );
+            Configuration.Services.Replace( typeof( ITraceWriter ), new TraceWriter() );
             Server = new HttpServer( Configuration );
             Client = new HttpClient( new HttpSimulatorHandler( Server ) )
             {

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/TraceWriter.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/TraceWriter.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Web
+{
+    using System;
+    using System.Net.Http;
+    using System.Web.Http.Tracing;
+
+    public sealed class TraceWriter : ITraceWriter
+    {
+        public void Trace( HttpRequestMessage request, string category, TraceLevel level, Action<TraceRecord> traceAction ) { }
+    }
+}

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/TestConfigurations.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/TestConfigurations.cs
@@ -3,10 +3,13 @@
     using Microsoft.Web.Http.Versioning.Conventions;
     using Models;
     using Simulators;
+    using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Web.Http;
     using System.Web.Http.Dispatcher;
+    using System.Web.Http.Tracing;
     using static System.Web.Http.RouteParameter;
 
     public class TestConfigurations : IEnumerable<object[]>
@@ -28,6 +31,7 @@
                 typeof( Values3Controller ) );
 
             configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), controllerTypeResolver );
+            configuration.Services.Replace( typeof( ITraceWriter ), new TraceWriter() );
             configuration.Routes.MapHttpRoute( "Default", "{controller}/{id}", new { id = Optional } );
             configuration.AddApiVersioning(
                 options =>
@@ -57,10 +61,16 @@
                 typeof( AttributeValues3Controller ) );
 
             configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), controllerTypeResolver );
+            configuration.Services.Replace( typeof( ITraceWriter ), new TraceWriter() );
             configuration.MapHttpAttributeRoutes();
             configuration.AddApiVersioning();
 
             return configuration;
+        }
+
+        sealed class TraceWriter : ITraceWriter
+        {
+            public void Trace( HttpRequestMessage request, string category, TraceLevel level, Action<TraceRecord> traceAction ) { }
         }
     }
 }


### PR DESCRIPTION
Corrects the matching of API versioned actions when an ITraceWriter is used. Acceptance tests and API explorer tests are updated to include a stub ITraceWriter to ensure there are no regressions. This PR fixes #119.