### PR TITLE
Fix MVC Routing in 1.1 RC2

### DIFF
--- a/ApiVersioningWithSamples.sln
+++ b/ApiVersioningWithSamples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4D5F5F21-0CB7-4B4E-A42F-732BD4AFD0FF}"
 EndProject

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersionActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersionActionSelector.cs
@@ -382,18 +382,39 @@
 
             internal ActionDescriptorMatch BestMatch { get; private set; }
 
+            RouteData NewMatchRouteData( ActionDescriptor match )
+            {
+                Contract.Requires( match != null );
+                Contract.Ensures( Contract.Result<RouteData>() != null );
+
+                var matchedRouteData = new RouteData( routeData );
+                var matchedRouteValues = matchedRouteData.Values;
+
+                foreach ( var entry in match.RouteValues )
+                {
+                    if ( !matchedRouteValues.ContainsKey( entry.Key ) )
+                    {
+                        matchedRouteValues.Add( entry.Key, entry.Value );
+                    }
+                }
+
+                return matchedRouteData;
+            }
+
             public IEnumerator<ActionDescriptorMatch> GetEnumerator()
             {
                 if ( matches.Count == 1 )
                 {
-                    BestMatch = new ActionDescriptorMatch( matches[0], routeData );
+                    var match = matches[0];
+                    BestMatch = new ActionDescriptorMatch( match, NewMatchRouteData( match ) );
                     yield return BestMatch;
                 }
                 else
                 {
                     for ( var i = 0; i < matches.Count; i++ )
                     {
-                        yield return new ActionDescriptorMatch( matches[i], routeData );
+                        var match = matches[i];
+                        yield return new ActionDescriptorMatch( match, NewMatchRouteData( match ) );
                     }
                 }
             }

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/BasicAcceptanceTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/BasicAcceptanceTest.cs
@@ -12,7 +12,7 @@
             FilteredControllerTypes.Add( typeof( Values2Controller ).GetTypeInfo() );
             FilteredControllerTypes.Add( typeof( HelloWorldController ).GetTypeInfo() );
             FilteredControllerTypes.Add( typeof( HelloWorld2Controller ).GetTypeInfo() );
-            FilteredControllerTypes.Add( typeof( HomeController ).GetTypeInfo() );
+            FilteredControllerTypes.Add( typeof( PingController ).GetTypeInfo() );
         }
 
         protected override void OnAddApiVersioning( ApiVersioningOptions options ) => options.ReportApiVersions = true;

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/Controllers/PingController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/Controllers/PingController.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Basic.Controllers
+{
+    using System;
+
+    [ApiVersionNeutral]
+    [Route( "api/[controller]" )]
+    public class PingController : Controller
+    {
+        [HttpGet]
+        public IActionResult Get() => NoContent();
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/Controllers/WithViewsUsingAttributes/HomeController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/Controllers/WithViewsUsingAttributes/HomeController.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Basic.Controllers.WithViewsUsingAttributes
+{
+    using System;
+
+    [ApiVersionNeutral]
+    [Route( "" )]
+    [Route( "[controller]" )]
+    public class HomeController : Controller
+    {
+        [HttpGet( "" )]
+        [HttpGet( nameof( Index ) )]
+        public IActionResult Index() => View();
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/Controllers/WithViewsUsingConventions/HomeController.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/Controllers/WithViewsUsingConventions/HomeController.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.AspNetCore.Mvc.Basic.Controllers
+﻿namespace Microsoft.AspNetCore.Mvc.Basic.Controllers.WithViewsUsingConventions
 {
     using System;
 

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral Controller/when no version is specified.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral Controller/when no version is specified.cs
@@ -1,0 +1,24 @@
+﻿namespace given_a_versionX2Dneutral_Controller
+{
+    using FluentAssertions;
+    using Microsoft.AspNetCore.Mvc.Basic;
+    using System.Threading.Tasks;
+    using Xunit;
+    using static System.Net.HttpStatusCode;
+
+    public class when_no_version_is_specified : BasicAcceptanceTest
+    {
+        [Fact]
+        public async Task then_get_should_return_204()
+        {
+            // arrange
+
+
+            // act
+            var response = await GetAsync( "api/ping" );
+
+            // assert
+            response.StatusCode.Should().Be( NoContent );
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral UI Controller/when accessing a view using attribute routing.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral UI Controller/when accessing a view using attribute routing.cs
@@ -3,16 +3,25 @@
     using FluentAssertions;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Basic;
+    using Microsoft.AspNetCore.Mvc.Basic.Controllers.WithViewsUsingAttributes;
     using System.Net.Http.Headers;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Xunit;
 
-    public class when_accessing_a_view : BasicAcceptanceTest
+    public class when_accessing_a_view_using_attribute_routing : BasicAcceptanceTest
     {
+        public when_accessing_a_view_using_attribute_routing()
+        {
+            FilteredControllerTypes.Clear();
+            FilteredControllerTypes.Add( typeof( HomeController ).GetTypeInfo() );
+        }
+
         [Theory]
         [InlineData( "http://localhost" )]
         [InlineData( "http://localhost/home" )]
         [InlineData( "http://localhost/home/index" )]
+        [InlineData( "http://localhost/index" )]
         public async Task then_get_should_return_200( string requestUrl )
         {
             // arrange

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral UI Controller/when accessing a view using convention routing.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral UI Controller/when accessing a view using convention routing.cs
@@ -1,0 +1,36 @@
+﻿namespace given_a_versionX2Dneutral_UI_Controller
+{
+    using FluentAssertions;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Basic;
+    using Microsoft.AspNetCore.Mvc.Basic.Controllers.WithViewsUsingConventions;
+    using System.Net.Http.Headers;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class when_accessing_a_view_using_convention_routing : BasicAcceptanceTest
+    {
+        public when_accessing_a_view_using_convention_routing()
+        {
+            FilteredControllerTypes.Clear();
+            FilteredControllerTypes.Add( typeof( HomeController ).GetTypeInfo() );
+        }
+
+        [Theory]
+        [InlineData( "http://localhost" )]
+        [InlineData( "http://localhost/home" )]
+        [InlineData( "http://localhost/home/index" )]
+        public async Task then_get_should_return_200( string requestUrl )
+        {
+            // arrange
+            Client.DefaultRequestHeaders.Accept.Add( new MediaTypeWithQualityHeaderValue( "text/html" ) );
+
+            // act
+            var response = await GetAsync( requestUrl ).EnsureSuccessStatusCode();
+
+            // assert
+            response.Content.Headers.ContentType.MediaType.Should().Be( "text/html" );
+        }
+    }
+}


### PR DESCRIPTION
Fixes routing for MVC views in ASP.NET Core 1.1 RC2 by copying the route values from matches into the results evaluated by the api versioning policy. Fixes #130.