### PR TITLE
Improve Cloning of MediaTypeFormatter

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Description/ApiVersionParameterDescriptionContext.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Description/ApiVersionParameterDescriptionContext.cs
@@ -6,11 +6,11 @@
     using System.Linq;
     using System.Net.Http.Formatting;
     using System.Net.Http.Headers;
+    using System.Web.Http;
     using System.Web.Http.Description;
     using static Microsoft.Web.Http.Versioning.ApiVersionParameterLocation;
-    using static System.Web.Http.Description.ApiParameterSource;
     using static System.StringComparison;
-    using System.Web.Http;
+    using static System.Web.Http.Description.ApiParameterSource;
 
     /// <summary>
     /// Represents an object that contains API version parameter descriptions.

--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/LocalSR.Designer.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/LocalSR.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Web.Http {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The media type formatter {0} could not be cloned. The type must either implement {1} or define a copy constructor with the signature &apos;{0}({0} formatter)&apos;..
+        ///   Looks up a localized string similar to The media type formatter {0} could not be cloned. The type must either implement {1}, define a copy constructor with the signature &apos;{0}({0} formatter)&apos;, or have a parameterless constructor..
         /// </summary>
         internal static string MediaTypeFormatterNotCloneable {
             get {

--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/LocalSR.resx
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/LocalSR.resx
@@ -121,6 +121,6 @@
     <value>The requested API version</value>
   </data>
   <data name="MediaTypeFormatterNotCloneable" xml:space="preserve">
-    <value>The media type formatter {0} could not be cloned. The type must either implement {1} or define a copy constructor with the signature '{0}({0} formatter)'.</value>
+    <value>The media type formatter {0} could not be cloned. The type must either implement {1}, define a copy constructor with the signature '{0}({0} formatter)', or have a parameterless constructor.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>1.0.0</VersionPrefix>
+  <VersionPrefix>1.0.1</VersionPrefix>
   <AssemblyVersion>1.0.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyName>Microsoft.AspNet.WebApi.Versioning.ApiExplorer</AssemblyName>
@@ -10,7 +10,7 @@
   <RootNamespace>Microsoft.Web.Http</RootNamespace>
   <DefineConstants>$(DefineConstants);WEBAPI</DefineConstants>
   <PackageTags>Microsoft;AspNet;AspNetWebAPI;Versioning;ApiExplorer</PackageTags>
-  <PackageReleaseNotes></PackageReleaseNotes>
+  <PackageReleaseNotes>• Improve cloning of MediaTypeFormatter (Issue #156)</PackageReleaseNotes>
  </PropertyGroup>
 
  <ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
@@ -170,11 +170,13 @@
             // arrange
             var configuration = new HttpConfiguration();
             var json = new JsonMediaTypeFormatter();
+            var formUrlEncoded = new FormUrlEncodedMediaTypeFormatter();
 
             configuration.Formatters.Clear();
             configuration.Formatters.Add( json );
+            configuration.Formatters.Add( formUrlEncoded );
 
-            var description = new ApiDescription() { SupportedResponseFormatters = { json } };
+            var description = new ApiDescription() { SupportedRequestBodyFormatters = { json, formUrlEncoded } };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
             var context = new ApiVersionParameterDescriptionContext( description, version, options );
@@ -183,7 +185,7 @@
             context.AddParameter( "v", MediaTypeParameter );
 
             // assert
-            var formatter = description.SupportedResponseFormatters.Single();
+            var formatter = description.SupportedRequestBodyFormatters[0];
 
             foreach ( var mediaType in formatter.SupportedMediaTypes )
             {
@@ -191,6 +193,14 @@
             }
 
             formatter.Should().NotBeSameAs( json );
+            formatter = description.SupportedRequestBodyFormatters[1];
+
+            foreach ( var mediaType in formatter.SupportedMediaTypes )
+            {
+                mediaType.Parameters.Single().Should().Be( new NameValueHeaderValue( "v", "1.0" ) );
+            }
+
+            formatter.Should().NotBeSameAs( formUrlEncoded );
         }
 
         [Fact]


### PR DESCRIPTION
Improves the process for automatically cloning MediaTypeFormatter instances by supporting parameterless constructors as well. The cloning process is required by the API explorer for Web API when API versioning is performed by media type.