### PR TITLE
Fix 405 Handling for API Version-Neutral Routes

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.AspNetCore.Mvc.Versioning.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.AspNetCore.Mvc.Versioning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>1.2.0</VersionPrefix>
+  <VersionPrefix>1.2.1</VersionPrefix>
   <AssemblyVersion>1.2.0.0</AssemblyVersion>
   <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
   <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
@@ -11,7 +11,7 @@
   <Description>A service API versioning library for Microsoft ASP.NET Core.</Description>
   <RootNamespace>Microsoft.AspNetCore.Mvc</RootNamespace>
   <PackageTags>Microsoft;AspNet;AspNetCore;Versioning</PackageTags>
-  <PackageReleaseNotes>• Remove need for UseApiVersioning (Issue #152)</PackageReleaseNotes>
+  <PackageReleaseNotes>• Fix 405 for API version-neutral routes (Issue #159)</PackageReleaseNotes>
  </PropertyGroup>
 
  <ItemGroup>

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/SR.Designer.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/SR.Designer.cs
@@ -170,6 +170,15 @@ namespace Microsoft.AspNetCore.Mvc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The HTTP resource that matches the request URI &apos;{0}&apos; is not supported..
+        /// </summary>
+        internal static string VersionNeutralResourceNotSupported {
+            get {
+                return ResourceManager.GetString("VersionNeutralResourceNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to At least one IApiVersionReader must be specified..
         /// </summary>
         internal static string ZeroApiVersionReaders {

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/SR.resx
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/SR.resx
@@ -154,6 +154,9 @@
   <data name="VersionedResourceNotSupported" xml:space="preserve">
     <value>The HTTP resource that matches the request URI '{0}' does not support the API version '{1}'.</value>
   </data>
+  <data name="VersionNeutralResourceNotSupported" xml:space="preserve">
+    <value>The HTTP resource that matches the request URI '{0}' is not supported.</value>
+  </data>
   <data name="ZeroApiVersionReaders" xml:space="preserve">
     <value>At least one IApiVersionReader must be specified.</value>
   </data>

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/Http/Basic/given a version-neutral ApiController/when no version is specified.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/Http/Basic/given a version-neutral ApiController/when no version is specified.cs
@@ -1,7 +1,9 @@
 ﻿namespace given_a_version_neutral_ApiController
 {
     using FluentAssertions;
+    using Microsoft.Web;
     using Microsoft.Web.Http.Basic;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using Xunit;
     using static System.Net.HttpStatusCode;
@@ -19,6 +21,32 @@
 
             // assert
             response.StatusCode.Should().Be( NoContent );
+        }
+
+        [Fact]
+        public async Task then_post_should_return_405()
+        {
+            // arrange
+            var entity = new { };
+
+            // act
+            var response = await PostAsync( "api/ping", entity );
+            var content = await response.Content.ReadAsAsync<OneApiErrorResponse>();
+
+            // assert
+            response.StatusCode.Should().Be( MethodNotAllowed );
+            response.Content.Headers.Allow.Should().BeEquivalentTo( "GET" );
+            content.Error.ShouldBeEquivalentTo(
+                new
+                {
+                    Code = "UnsupportedApiVersion",
+                    InnerError = new
+                    {
+                        Code = default( string ),
+                        Message = "No route providing a controller name with API version '(null)' was found to match request URI 'http://localhost/api/ping'."
+                    },
+                    Message = "The HTTP resource that matches the request URI 'http://localhost/api/ping' does not support the API version '(null)'."
+                } );
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral Controller/when no version is specified.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Basic/given a version-neutral Controller/when no version is specified.cs
@@ -1,7 +1,9 @@
 ﻿namespace given_a_versionX2Dneutral_Controller
 {
     using FluentAssertions;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Basic;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using Xunit;
     using static System.Net.HttpStatusCode;
@@ -19,6 +21,28 @@
 
             // assert
             response.StatusCode.Should().Be( NoContent );
+        }
+
+        [Fact]
+        public async Task then_post_should_return_405()
+        {
+            // arrange
+            var entity = new { };
+
+            // act
+            var response = await PostAsync( "api/ping", entity );
+            var content = await response.Content.ReadAsAsync<OneApiErrorResponse>();
+
+            // assert
+            response.StatusCode.Should().Be( MethodNotAllowed );
+            response.Content.Headers.Allow.Should().BeEquivalentTo( "GET" );
+            content.Error.ShouldBeEquivalentTo(
+                new
+                {
+                    Code = "UnsupportedApiVersion",
+                    InnerError = default( OneApiInnerError ),
+                    Message = "The HTTP resource that matches the request URI 'http://localhost/api/ping' is not supported."
+                } );
         }
     }
 }


### PR DESCRIPTION
Updates route handling for API version-neutral routes to correctly return 405 when the only reason they are not matched is due to an unsupported HTTP method.