### PR TITLE
Fix Cloning of MediaTypeFormatter.SupportedMediaTypes

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Description/ApiVersionParameterDescriptionContext.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Description/ApiVersionParameterDescriptionContext.cs
@@ -158,9 +158,13 @@
 
             CloneFormattersAndAddMediaTypeParameter( parameter, ApiDescription.SupportedRequestBodyFormatters );
             CloneFormattersAndAddMediaTypeParameter( parameter, ApiDescription.SupportedResponseFormatters );
+            parameters.Add( NewApiVersionParameter( name, Unknown, allowOptional: false ) );
         }
 
-        ApiParameterDescription NewApiVersionParameter( string name, ApiParameterSource source )
+        ApiParameterDescription NewApiVersionParameter( string name, ApiParameterSource source ) =>
+            NewApiVersionParameter( name, source, optional );
+
+        ApiParameterDescription NewApiVersionParameter( string name, ApiParameterSource source, bool allowOptional )
         {
             Contract.Requires( !string.IsNullOrEmpty( name ) );
             Contract.Ensures( Contract.Result<ApiParameterDescription>() != null );
@@ -170,7 +174,7 @@
             {
                 Name = name,
                 Documentation = Options.DefaultApiVersionParameterDescription,
-                ParameterDescriptor = new ApiVersionParameterDescriptor( name, ApiVersion.ToString(), optional )
+                ParameterDescriptor = new ApiVersionParameterDescriptor( name, ApiVersion.ToString(), allowOptional )
                 {
                     Configuration = action.Configuration,
                     ActionDescriptor = action

--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>1.0.1</VersionPrefix>
+  <VersionPrefix>1.0.2</VersionPrefix>
   <AssemblyVersion>1.0.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyName>Microsoft.AspNet.WebApi.Versioning.ApiExplorer</AssemblyName>
@@ -10,7 +10,7 @@
   <RootNamespace>Microsoft.Web.Http</RootNamespace>
   <DefineConstants>$(DefineConstants);WEBAPI</DefineConstants>
   <PackageTags>Microsoft;AspNet;AspNetWebAPI;Versioning;ApiExplorer</PackageTags>
-  <PackageReleaseNotes>• Improve cloning of MediaTypeFormatter (Issue #156)</PackageReleaseNotes>
+  <PackageReleaseNotes>• Fix cloning MediaTypeFormatter.SupportedMediaTypes (Issue #164)</PackageReleaseNotes>
  </PropertyGroup>
 
  <ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
@@ -169,14 +169,20 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
+            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
             var json = new JsonMediaTypeFormatter();
             var formUrlEncoded = new FormUrlEncodedMediaTypeFormatter();
 
             configuration.Formatters.Clear();
             configuration.Formatters.Add( json );
             configuration.Formatters.Add( formUrlEncoded );
+            action.Configuration = configuration;
 
-            var description = new ApiDescription() { SupportedRequestBodyFormatters = { json, formUrlEncoded } };
+            var description = new ApiDescription()
+            {
+                ActionDescriptor = action,
+                SupportedRequestBodyFormatters = { json, formUrlEncoded }
+            };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
             var context = new ApiVersionParameterDescriptionContext( description, version, options );


### PR DESCRIPTION
The existing cloning support for MediaTypeFormatter instances does not correctly clone the SupportedMediaTypes collection when cloning instances using a discovered copy constructor.

This PR adds some additional Reflection hackery to clone the media type values per formatter, per documented API version.