### PR TITLE
Report API Versions When Unmatched

### DIFF
--- a/src/Common/Versioning/ApiVersionReader.cs
+++ b/src/Common/Versioning/ApiVersionReader.cs
@@ -97,11 +97,11 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
                 return versions.EnsureZeroOrOneApiVersions();
             }
 
-            public void AddParmeters( IApiVersionParameterDescriptionContext context )
+            public void AddParameters( IApiVersionParameterDescriptionContext context )
             {
                 foreach ( var apiVersionReader in apiVersionReaders )
                 {
-                    apiVersionReader.AddParmeters( context );
+                    apiVersionReader.AddParameters( context );
                 }
             }
         }

--- a/src/Common/Versioning/HeaderApiVersionReader.cs
+++ b/src/Common/Versioning/HeaderApiVersionReader.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// Provides API version parameter descriptions supported by the current reader using the supplied provider.
         /// </summary>
         /// <param name="context">The <see cref="IApiVersionParameterDescriptionContext">context</see> used to add API version parameter descriptions.</param>
-        public virtual void AddParmeters( IApiVersionParameterDescriptionContext context )
+        public virtual void AddParameters( IApiVersionParameterDescriptionContext context )
         {
             Arg.NotNull( context, nameof( context ) );
 

--- a/src/Common/Versioning/IApiVersionParameterSource.cs
+++ b/src/Common/Versioning/IApiVersionParameterSource.cs
@@ -13,6 +13,6 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// Provides API version parameter descriptions supported by the current source using the supplied context.
         /// </summary>
         /// <param name="context">The <see cref="IApiVersionParameterDescriptionContext">context</see> used to add API version parameter descriptions.</param>
-        void AddParmeters( IApiVersionParameterDescriptionContext context );
+        void AddParameters( IApiVersionParameterDescriptionContext context );
     }
 }

--- a/src/Common/Versioning/MediaTypeApiVersionReader.cs
+++ b/src/Common/Versioning/MediaTypeApiVersionReader.cs
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// Provides API version parameter descriptions supported by the current reader using the supplied provider.
         /// </summary>
         /// <param name="context">The <see cref="IApiVersionParameterDescriptionContext">context</see> used to add API version parameter descriptions.</param>
-        public virtual void AddParmeters( IApiVersionParameterDescriptionContext context )
+        public virtual void AddParameters( IApiVersionParameterDescriptionContext context )
         {
             Arg.NotNull( context, nameof( context ) );
             context.AddParameter( ParameterName, MediaTypeParameter );

--- a/src/Common/Versioning/QueryStringApiVersionReader.cs
+++ b/src/Common/Versioning/QueryStringApiVersionReader.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// Provides API version parameter descriptions supported by the current reader using the supplied provider.
         /// </summary>
         /// <param name="context">The <see cref="IApiVersionParameterDescriptionContext">context</see> used to add API version parameter descriptions.</param>
-        public virtual void AddParmeters( IApiVersionParameterDescriptionContext context )
+        public virtual void AddParameters( IApiVersionParameterDescriptionContext context )
         {
             Arg.NotNull( context, nameof( context ) );
             context.AddParameter( ParameterName, Query );

--- a/src/Common/Versioning/UrlSegmentApiVersionReader.cs
+++ b/src/Common/Versioning/UrlSegmentApiVersionReader.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// Provides API version parameter descriptions supported by the current reader using the supplied provider.
         /// </summary>
         /// <param name="context">The <see cref="IApiVersionParameterDescriptionContext">context</see> used to add API version parameter descriptions.</param>
-        public virtual void AddParmeters( IApiVersionParameterDescriptionContext context )
+        public virtual void AddParameters( IApiVersionParameterDescriptionContext context )
         {
             Arg.NotNull( context, nameof( context ) );
 

--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Description/VersionedApiExplorer.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Description/VersionedApiExplorer.cs
@@ -638,7 +638,7 @@
             var parameterSource = Options.ApiVersionParameterSource;
             var context = new ApiVersionParameterDescriptionContext( apiDescription, apiVersion, Options );
 
-            parameterSource.AddParmeters( context );
+            parameterSource.AddParameters( context );
         }
 
         void ExploreRouteActions(

--- a/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/VersionedApiDescriptionProvider.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/VersionedApiDescriptionProvider.cs
@@ -100,7 +100,7 @@
             var parameterSource = Options.ApiVersionParameterSource;
             var context = new ApiVersionParameterDescriptionContext( apiDescription, apiVersion, modelMetadata.Value, Options );
 
-            parameterSource.AddParmeters( context );
+            parameterSource.AddParameters( context );
         }
 
         /// <summary>

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/HeaderApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/HeaderApiVersionReaderTest.cs
@@ -70,7 +70,7 @@
             context.Setup( c => c.AddParameter( It.IsAny<string>(), It.IsAny<ApiVersionParameterLocation>() ) );
 
             // act
-            reader.AddParmeters( context.Object );
+            reader.AddParameters( context.Object );
 
             // assert
             context.Verify( c => c.AddParameter( "api-version", Header ), Times.Once() );

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/MediaTypeApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/MediaTypeApiVersionReaderTest.cs
@@ -167,7 +167,7 @@
             context.Setup( c => c.AddParameter( It.IsAny<string>(), It.IsAny<ApiVersionParameterLocation>() ) );
 
             // act
-            reader.AddParmeters( context.Object );
+            reader.AddParameters( context.Object );
 
             // assert
             context.Verify( c => c.AddParameter( "v", MediaTypeParameter ), Times.Once() );

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/QueryStringApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/QueryStringApiVersionReaderTest.cs
@@ -91,7 +91,7 @@
             context.Setup( c => c.AddParameter( It.IsAny<string>(), It.IsAny<ApiVersionParameterLocation>() ) );
 
             // act
-            reader.AddParmeters( context.Object );
+            reader.AddParameters( context.Object );
 
             // assert
             context.Verify( c => c.AddParameter( "api-version", Query ), Times.Once() );

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/QueryStringOrHeaderApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/QueryStringOrHeaderApiVersionReaderTest.cs
@@ -70,7 +70,7 @@
             context.Setup( c => c.AddParameter( It.IsAny<string>(), It.IsAny<ApiVersionParameterLocation>() ) );
 
             // act
-            reader.AddParmeters( context.Object );
+            reader.AddParameters( context.Object );
 
             // assert
             context.Verify( c => c.AddParameter( "api-version", Query ), Times.Once() );

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/UrlSegmentApiVersionReaderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/UrlSegmentApiVersionReaderTest.cs
@@ -59,7 +59,7 @@
             context.Setup( c => c.AddParameter( It.IsAny<string>(), It.IsAny<ApiVersionParameterLocation>() ) );
 
             // act
-            reader.AddParmeters( context.Object );
+            reader.AddParameters( context.Object );
 
             // assert
             context.Verify( c => c.AddParameter( null, Path ), Times.Once() );


### PR DESCRIPTION
Refactors the internal mechanics for reporting API versions into the IReportApiVersions interface. This service can be requested or changed through dependency injection. This change will allow the SDK to report API versions in both the matched, and now unmatched, cases. Resolves #187.