### PR TITLE
Report API Versions When Unmatched

### DIFF
--- a/src/Common/Common.projitems
+++ b/src/Common/Common.projitems
@@ -48,7 +48,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\Conventions\IActionConventionBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\Conventions\IApiVersionConventionT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\CurrentImplementationApiVersionSelector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Versioning\DefaultApiVersionReporter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\DefaultApiVersionSelector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Versioning\DoNotReportApiVersions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\ErrorCodes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\ErrorResponseContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\HeaderApiVersionReader.cs" />
@@ -59,6 +61,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IErrorResponseProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Versioning\IReportApiVersions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\LowestImplementedApiVersionSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\MediaTypeApiVersionReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\QueryStringApiVersionReader.cs" />

--- a/src/Common/ReportApiVersionsAttribute.cs
+++ b/src/Common/ReportApiVersionsAttribute.cs
@@ -20,8 +20,5 @@ namespace Microsoft.AspNetCore.Mvc
     [AttributeUsage( Class | Method, Inherited = true, AllowMultiple = false )]
     public sealed partial class ReportApiVersionsAttribute : ActionFilterAttribute
     {
-        const string ApiSupportedVersions = "api-supported-versions";
-        const string ApiDeprecatedVersions = "api-deprecated-versions";
-        const string ValueSeparator = ", ";
     }
 }

--- a/src/Common/Versioning/DefaultApiVersionReporter.cs
+++ b/src/Common/Versioning/DefaultApiVersionReporter.cs
@@ -1,0 +1,53 @@
+﻿#if WEBAPI
+namespace Microsoft.Web.Http.Versioning
+#else
+namespace Microsoft.AspNetCore.Mvc.Versioning
+#endif
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Linq;
+    using static System.String;
+#if WEBAPI
+    using System.Net.Http.Headers;
+#else
+    using HttpResponseHeaders = Microsoft.AspNetCore.Http.IHeaderDictionary;
+#endif
+
+    sealed partial class DefaultApiVersionReporter : IReportApiVersions
+    {
+        const string ApiSupportedVersions = "api-supported-versions";
+        const string ApiDeprecatedVersions = "api-deprecated-versions";
+        const string ValueSeparator = ", ";
+
+        public void Report( HttpResponseHeaders headers, Lazy<ApiVersionModel> apiVersionModel ) =>
+            Report( headers, apiVersionModel?.Value );
+
+        public void Report( HttpResponseHeaders headers, ApiVersionModel apiVersionModel )
+        {
+            Arg.NotNull( headers, nameof( headers ) );
+            Arg.NotNull( apiVersionModel, nameof( apiVersionModel ) );
+
+            AddApiVersionHeader( headers, ApiSupportedVersions, apiVersionModel.SupportedApiVersions );
+            AddApiVersionHeader( headers, ApiDeprecatedVersions, apiVersionModel.DeprecatedApiVersions );
+        }
+
+        static void AddApiVersionHeader( HttpResponseHeaders headers, string headerName, IReadOnlyList<ApiVersion> versions )
+        {
+            Contract.Requires( headers != null );
+            Contract.Requires( !IsNullOrEmpty( headerName ) );
+            Contract.Requires( versions != null );
+
+            if ( versions.Count > 0 &&
+#if WEBAPI
+                !headers.Contains( headerName ) )
+#else
+                !headers.ContainsKey( headerName ) )
+#endif
+            {
+                headers.Add( headerName, Join( ValueSeparator, versions.Select( v => v.ToString() ).ToArray() ) );
+            }
+        }
+    }
+}

--- a/src/Common/Versioning/DoNotReportApiVersions.cs
+++ b/src/Common/Versioning/DoNotReportApiVersions.cs
@@ -1,0 +1,20 @@
+﻿#if WEBAPI
+namespace Microsoft.Web.Http.Versioning
+#else
+namespace Microsoft.AspNetCore.Mvc.Versioning
+#endif
+{
+    using System;
+#if WEBAPI
+    using System.Net.Http.Headers;
+#else
+    using HttpResponseHeaders = Microsoft.AspNetCore.Http.IHeaderDictionary;
+#endif
+
+    sealed partial class DoNotReportApiVersions : IReportApiVersions
+    {
+        public void Report( HttpResponseHeaders headers, ApiVersionModel apiVersionModel ) { }
+
+        public void Report( HttpResponseHeaders headers, Lazy<ApiVersionModel> apiVersionModel ) { }
+    }
+}

--- a/src/Common/Versioning/IReportApiVersions.cs
+++ b/src/Common/Versioning/IReportApiVersions.cs
@@ -1,0 +1,36 @@
+﻿#if WEBAPI
+namespace Microsoft.Web.Http.Versioning
+#else
+namespace Microsoft.AspNetCore.Mvc.Versioning
+#endif
+{
+    using System;
+#if WEBAPI
+    using System.Net.Http.Headers;
+#else
+    using HttpResponseHeaders = Microsoft.AspNetCore.Http.IHeaderDictionary;
+#endif
+
+    /// <summary>
+    /// Defines the behavior of an object that reports API versions as HTTP headers.
+    /// </summary>
+#if !WEBAPI
+    [CLSCompliant( false )]
+#endif
+    public interface IReportApiVersions
+    {
+        /// <summary>
+        /// Reports the API versions defined in the specified models using the the provided collection of HTTP headers.
+        /// </summary>
+        /// <param name="headers">The collection of <see cref="HttpResponseHeaders">HTTP response headers</see> used to report API versions.</param>
+        /// <param name="apiVersionModel">The <see cref="ApiVersionModel">model</see> containing the API versions to report.</param>
+        void Report( HttpResponseHeaders headers, ApiVersionModel apiVersionModel );
+
+        /// <summary>
+        /// Reports the API versions defined in the specified models using the the provided collection of HTTP headers.
+        /// </summary>
+        /// <param name="headers">The collection of <see cref="HttpResponseHeaders">HTTP response headers</see> used to report API versions.</param>
+        /// <param name="apiVersionModel">The load on-demand <see cref="ApiVersionModel">model</see> containing the API versions to report.</param>
+        void Report( HttpResponseHeaders headers, Lazy<ApiVersionModel> apiVersionModel );
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ActionSelectorCacheItem.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ActionSelectorCacheItem.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.Web.Http.Controllers
 {
     using Dispatcher;
+    using Microsoft.Web.Http.Versioning;
     using Routing;
     using System;
     using System.Collections.Generic;
@@ -211,10 +212,10 @@
                 }
 
                 var request = controllerContext.Request;
-                var versionNeutral = controllerContext.ControllerDescriptor.GetApiVersionModel().IsApiVersionNeutral;
-                var exceptionFactory = new HttpResponseExceptionFactory( request );
+                var model = controllerContext.ControllerDescriptor.GetApiVersionModel();
+                var exceptionFactory = new HttpResponseExceptionFactory( request, new Lazy<ApiVersionModel>( () => model ) );
 
-                return exceptionFactory.CreateMethodNotAllowedResponse( versionNeutral, allowedMethods );
+                return exceptionFactory.CreateMethodNotAllowedResponse( model.IsApiVersionNeutral, allowedMethods );
             }
 
             [SuppressMessage( "Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller is responsible for disposing of response instance." )]
@@ -224,7 +225,8 @@
                 Contract.Ensures( Contract.Result<HttpResponseMessage>() != null );
 
                 var request = controllerContext.Request;
-                var exceptionFactory = new HttpResponseExceptionFactory( request );
+                var model = new Lazy<ApiVersionModel>( controllerContext.ControllerDescriptor.GetApiVersionModel );
+                var exceptionFactory = new HttpResponseExceptionFactory( request, model );
                 return exceptionFactory.CreateBadRequestResponse( request.GetRequestedApiVersion() );
             }
 
@@ -302,10 +304,10 @@
                     if ( actionsFoundByName.Length == 0 )
                     {
                         var request = controllerContext.Request;
-                        var versionNeutral = controllerContext.ControllerDescriptor.GetApiVersionModel().IsApiVersionNeutral;
-                        var exceptionFactory = new HttpResponseExceptionFactory( request );
+                        var model = controllerContext.ControllerDescriptor.GetApiVersionModel();
+                        var exceptionFactory = new HttpResponseExceptionFactory( request, new Lazy<ApiVersionModel>( () => model ) );
 
-                        throw exceptionFactory.NewMethodNotAllowedException( versionNeutral, allowedMethods );
+                        throw exceptionFactory.NewMethodNotAllowedException( model.IsApiVersionNeutral, allowedMethods );
                     }
 
                     var candidatesFoundByName = new CandidateAction[actionsFoundByName.Length];

--- a/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ApiVersionActionSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Controllers/ApiVersionActionSelector.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.Web.Http.Controllers
 {
     using Dispatcher;
+    using Microsoft.Web.Http.Versioning;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
@@ -70,7 +71,8 @@
 
             var request = controllerContext.Request;
             var requestedVersion = request.GetRequestedApiVersion();
-            var exceptionFactory = new HttpResponseExceptionFactory( request );
+            var model = new Lazy<ApiVersionModel>( controllerContext.ControllerDescriptor.GetApiVersionModel );
+            var exceptionFactory = new HttpResponseExceptionFactory( request, model );
 
             if ( candidateActions.Count == 1 )
             {

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ApiVersionControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ApiVersionControllerSelector.cs
@@ -74,7 +74,7 @@
             var aggregator = new ApiVersionControllerAggregator( request, GetControllerName, controllerInfoCache );
             var conventionRouteSelector = new ConventionRouteControllerSelector( options, controllerTypeCache );
             var conventionRouteResult = default( ControllerSelectionResult );
-            var exceptionFactory = new HttpResponseExceptionFactory( request );
+            var exceptionFactory = new HttpResponseExceptionFactory( request, new Lazy<ApiVersionModel>( () => aggregator.AllVersions ) );
 
             if ( aggregator.RouteData == null )
             {

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DefaultApiVersionReporter.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DefaultApiVersionReporter.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Web.Http.Versioning
+{
+    using System;
+
+    partial class DefaultApiVersionReporter
+    {
+        DefaultApiVersionReporter() { }
+
+        internal static IReportApiVersions Instance { get; } = new DefaultApiVersionReporter();
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DoNotReportApiVersions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/DoNotReportApiVersions.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Web.Http.Versioning
+{
+    using System;
+
+    partial class DoNotReportApiVersions
+    {
+        DoNotReportApiVersions() { }
+
+        internal static IReportApiVersions Instance { get; } = new DoNotReportApiVersions();
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.Extensions.DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.Extensions.DependencyInjection/IServiceCollectionExtensions.cs
@@ -45,9 +45,19 @@
             services.Add( Singleton<IOptions<ApiVersioningOptions>>( new OptionsWrapper<ApiVersioningOptions>( options ) ) );
             services.Replace( Singleton<IActionSelector, ApiVersionActionSelector>() );
             services.TryAddSingleton<IApiVersionRoutePolicy, DefaultApiVersionRoutePolicy>();
+            services.TryAddSingleton<ReportApiVersionsAttribute>();
             services.AddTransient<IStartupFilter, InjectApiVersionRoutePolicy>();
             services.AddMvcCore( mvcOptions => AddMvcOptions( mvcOptions, options ) );
             services.AddRouting( routeOptions => routeOptions.ConstraintMap.Add( "apiVersion", typeof( ApiVersionRouteConstraint ) ) );
+
+            if ( options.ReportApiVersions )
+            {
+                services.TryAddSingleton<IReportApiVersions, DefaultApiVersionReporter>();
+            }
+            else
+            {
+                services.TryAddSingleton<IReportApiVersions, DoNotReportApiVersions>();
+            }
 
             return services;
         }
@@ -59,7 +69,7 @@
 
             if ( options.ReportApiVersions )
             {
-                mvcOptions.Filters.Add( new ReportApiVersionsAttribute() );
+                mvcOptions.Filters.AddService<ReportApiVersionsAttribute>();
             }
 
             mvcOptions.Conventions.Add( new ApiVersionConvention( options.DefaultApiVersion, options.Conventions ) );

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersionActionSelector.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersionActionSelector.cs
@@ -298,7 +298,12 @@
             {
                 Logger.LogInformation( ex.Message );
                 apiVersion = default( ApiVersion );
-                return new BadRequestHandler( Options.ErrorResponses, AmbiguousApiVersion, ex.Message );
+                var handlerContext = new RequestHandlerContext( Options.ErrorResponses )
+                {
+                    Code = AmbiguousApiVersion,
+                    Message = ex.Message
+                };
+                return new BadRequestHandler( handlerContext );
             }
 
             return null;

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/BadRequestHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/BadRequestHandler.cs
@@ -4,10 +4,9 @@
 
     sealed class BadRequestHandler : RequestHandler
     {
-        internal BadRequestHandler( IErrorResponseProvider errorResponseProvider, string code, string message )
-            : base( errorResponseProvider, code, message ) { }
+        internal BadRequestHandler( RequestHandlerContext context ) : base( context ) { }
 
-        protected override IActionResult CreateResult( HttpContext context ) =>
-            ErrorResponses.BadRequest( context, Code, Message );
+        protected override IActionResult CreateResult( HttpContext httpContext ) =>
+            Context.ErrorResponses.BadRequest( httpContext, Context.Code, Context.Message );
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/MethodNotAllowedHandler.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/MethodNotAllowedHandler.cs
@@ -8,19 +8,13 @@
 
     sealed class MethodNotAllowedHandler : RequestHandler
     {
-        readonly string[] allowedMethods;
+        internal MethodNotAllowedHandler( RequestHandlerContext context ) : base( context ) { }
 
-        internal MethodNotAllowedHandler( IErrorResponseProvider errorResponseProvider, string code, string message, string[] allowedMethods )
-            : base( errorResponseProvider, code, message )
+        protected override IActionResult CreateResult( HttpContext httpContext )
         {
-            Contract.Requires( allowedMethods != null );
-            this.allowedMethods = allowedMethods;
-        }
-
-        protected override IActionResult CreateResult( HttpContext context )
-        {
-            var result = ErrorResponses.MethodNotAllowed( context, Code, Message );
-            return allowedMethods.Length == 0 ? result : new AllowHeaderResult( result, allowedMethods );
+            var result = Context.ErrorResponses.MethodNotAllowed( httpContext, Context.Code, Context.Message );
+            var allowedMethods = Context.AllowedMethods;
+            return allowedMethods?.Length > 0 ? new AllowHeaderResult( result, allowedMethods ) : result;
         }
 
         sealed class AllowHeaderResult : IActionResult

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/RequestHandlerContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/RequestHandlerContext.cs
@@ -1,0 +1,45 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Versioning
+{
+    using Microsoft.AspNetCore.Http;
+    using System;
+    using System.Diagnostics.Contracts;
+
+    sealed class RequestHandlerContext
+    {
+        readonly IReportApiVersions reporter;
+        readonly Lazy<ApiVersionModel> apiVersions;
+
+        internal RequestHandlerContext( IErrorResponseProvider errorResponseProvider )
+            : this( errorResponseProvider, null, null ) { }
+
+        internal RequestHandlerContext(
+            IErrorResponseProvider errorResponseProvider,
+            IReportApiVersions reportApiVersions,
+            Lazy<ApiVersionModel> apiVersions )
+        {
+            Contract.Requires( errorResponseProvider != null );
+
+            ErrorResponses = errorResponseProvider;
+            reporter = reportApiVersions;
+            this.apiVersions = apiVersions;
+        }
+
+        internal IErrorResponseProvider ErrorResponses { get; }
+
+        internal string Message { get; set; }
+
+        internal string Code { get; set; }
+
+        internal string[] AllowedMethods { get; set; }
+
+        internal void ReportApiVersions( HttpResponse response )
+        {
+            Contract.Requires( response != null );
+
+            if ( reporter != null && apiVersions != null )
+            {
+                reporter.Report( response.Headers, apiVersions );
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests.csproj
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests.csproj
@@ -16,10 +16,10 @@
  </ItemGroup>
  
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.2" />
-  <PackageReference Include="Moq" Version="4.7.0" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="System.Runtime" Version="4.1.0" />
   <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
  </ItemGroup>

--- a/test/Microsoft.AspNet.OData.Versioning.Tests/Microsoft.AspNet.OData.Versioning.Tests.csproj
+++ b/test/Microsoft.AspNet.OData.Versioning.Tests/Microsoft.AspNet.OData.Versioning.Tests.csproj
@@ -15,10 +15,10 @@
  </ItemGroup>
  
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.2" />
-  <PackageReference Include="Moq" Version="4.7.0" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="System.Runtime" Version="4.1.0" />
   <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
  </ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/Microsoft.AspNet.WebApi.Acceptance.Tests.csproj
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/Microsoft.AspNet.WebApi.Acceptance.Tests.csproj
@@ -18,11 +18,11 @@
  </ItemGroup>
 
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.2" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
   <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" />
-  <PackageReference Include="Moq" Version="4.7.0" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="System.Runtime" Version="4.1.0" />
   <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
  </ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests.csproj
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests.csproj
@@ -15,10 +15,10 @@
  </ItemGroup>
  
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.2" />
-  <PackageReference Include="Moq" Version="4.7.0" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="System.Runtime" Version="4.1.0" />
   <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
  </ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
@@ -208,7 +208,7 @@
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=42.0" );
 
             configuration.IncludeErrorDetailPolicy = Always;
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -225,6 +225,8 @@
 
             // assert
             response.StatusCode.Should().Be( BadRequest );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
             content.ShouldBeEquivalentTo(
                 new
                 {
@@ -248,7 +250,7 @@
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=2016-06-32" );
 
             configuration.IncludeErrorDetailPolicy = Always;
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -265,6 +267,8 @@
 
             // assert
             response.StatusCode.Should().Be( BadRequest );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
             content.ShouldBeEquivalentTo(
                 new
                 {
@@ -288,7 +292,7 @@
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=4.0" );
 
             configuration.IncludeErrorDetailPolicy = Always;
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.Routes.MapHttpRoute( "Default", "api/{controller}/{id}", new { id = Optional } );
             configuration.EnsureInitialized();
 
@@ -306,6 +310,8 @@
 
             // assert
             response.StatusCode.Should().Be( BadRequest );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "1.8, 1.9" );
             content.ShouldBeEquivalentTo(
                 new
                 {
@@ -329,7 +335,7 @@
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=2016-06-32" );
 
             configuration.IncludeErrorDetailPolicy = Always;
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.Routes.MapHttpRoute( "Default", "api/{controller}/{id}", new { id = Optional } );
             configuration.EnsureInitialized();
 
@@ -347,6 +353,8 @@
 
             // assert
             response.StatusCode.Should().Be( BadRequest );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "1.8, 1.9" );
             content.ShouldBeEquivalentTo(
                 new
                 {
@@ -401,7 +409,7 @@
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, "http://localhost/api/test" );
 
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -418,6 +426,8 @@
 
             // assert
             response.StatusCode.Should().Be( BadRequest );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
         }
 
         [Fact]
@@ -427,7 +437,7 @@
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, "http://localhost/api/test/1?api-version=2.0" );
 
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -442,6 +452,8 @@
 
             // assert
             response.StatusCode.Should().Be( BadRequest );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
         }
 
         [Fact]
@@ -451,7 +463,7 @@
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Post, "http://localhost/api/test?api-version=1.0" );
 
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( o => o.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -477,6 +489,8 @@
 
             // assert
             response.StatusCode.Should().Be( MethodNotAllowed );
+            response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+            response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Microsoft.AspNet.WebApi.Versioning.Tests.csproj
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Microsoft.AspNet.WebApi.Versioning.Tests.csproj
@@ -16,10 +16,10 @@
  </ItemGroup>
  
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.2" />
-  <PackageReference Include="Moq" Version="4.7.0" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="System.Runtime" Version="4.1.0" />
   <PackageReference Include="System.Threading.Tasks" Version="4.0.11" />
  </ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Simulators/TestVersion2Controller.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Simulators/TestVersion2Controller.cs
@@ -17,7 +17,6 @@
 
         public Task<string> Get() => Task.FromResult( "Test" );
 
-        [MapToApiVersion( "3.0-Alpha" )]
         [MapToApiVersion( "3.0" )]
         public Task<string> Get3() => Task.FromResult( "Test" );
     }

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpActionDescriptorExtensionsTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpActionDescriptorExtensionsTest.cs
@@ -32,7 +32,7 @@
                 var runs = new[]
                 {
                     Tuple.Create( typeof( TestController ), nameof( TestController.Get ), new ApiVersion[0] ),
-                    Tuple.Create( typeof( TestVersion2Controller ), nameof( TestVersion2Controller.Get3 ), new[] { new ApiVersion( 3, 0 ), new ApiVersion( 3, 0, "Alpha" ) } )
+                    Tuple.Create( typeof( TestVersion2Controller ), nameof( TestVersion2Controller.Get3 ), new[] { new ApiVersion( 3, 0 ) } )
                 };
                 return CreateActionDescriptorData( runs );
             }

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Microsoft.AspNetCore.Mvc.Acceptance.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Microsoft.AspNetCore.Mvc.Acceptance.Tests.csproj
@@ -16,10 +16,10 @@
  </ItemGroup>
 
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.3" />
-  <PackageReference Include="Moq" Version="4.7.99" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4-*" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
   <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests.csproj
@@ -16,10 +16,10 @@
  </ItemGroup>
 
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.3" />
-  <PackageReference Include="Moq" Version="4.7.99" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.0" />
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Microsoft.AspNetCore.Mvc.Versioning.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Microsoft.AspNetCore.Mvc.Versioning.Tests.csproj
@@ -16,10 +16,10 @@
  </ItemGroup>
 
  <ItemGroup>
-  <PackageReference Include="FluentAssertions" Version="4.19.3" />
-  <PackageReference Include="Moq" Version="4.7.99" />
-  <PackageReference Include="more.xunit" Version="2.2.3" />
-  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.2.3" />
+  <PackageReference Include="FluentAssertions" Version="4.19.4" />
+  <PackageReference Include="Moq" Version="4.7.142" />
+  <PackageReference Include="more.xunit" Version="2.3.1" />
+  <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
   <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
   <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Microsoft.Extensions.DependencyInjection/IServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Microsoft.Extensions.DependencyInjection/IServiceCollectionExtensionsTest.cs
@@ -69,7 +69,7 @@
             services.Single( sd => sd.ServiceType == typeof( IApiVersionReader ) ).ImplementationInstance.Should().NotBeNull();
             services.Single( sd => sd.ServiceType == typeof( IApiVersionSelector ) ).ImplementationInstance.Should().BeOfType<ConstantApiVersionSelector>();
             services.Single( sd => sd.ServiceType == typeof( IActionSelector ) ).ImplementationType.Should().Be( typeof( ApiVersionActionSelector ) );
-            mvcOptions.Filters.Single().Should().BeOfType<ReportApiVersionsAttribute>();
+            mvcOptions.Filters.OfType<ServiceFilterAttribute>().Single().ServiceType.Should().Be( typeof( ReportApiVersionsAttribute ) );
             mvcOptions.Conventions.Single().Should().BeOfType<ApiVersionConvention>();
             routeOptions.ConstraintMap["apiVersion"].Should().Be( typeof( ApiVersionRouteConstraint ) );
         }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/TestVersion2Controller.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Simulators/TestVersion2Controller.cs
@@ -14,7 +14,6 @@
         public Task<string> Get() => Task.FromResult( "Test" );
 
         [HttpGet]
-        [MapToApiVersion( "3.0-Alpha" )]
         [MapToApiVersion( "3.0" )]
         public Task<string> Get3() => Task.FromResult( "Test" );
     }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/ApiVersionActionSelectorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/ApiVersionActionSelectorTest.cs
@@ -107,13 +107,15 @@
         public async Task select_best_candidate_should_return_400_for_unmatchedX2C_attributeX2Dbased_controller_version()
         {
             // arrange
-            using ( var server = new WebServer() )
+            using ( var server = new WebServer( options => options.ReportApiVersions = true ) )
             {
                 // act
                 var response = await server.Client.GetAsync( "http://localhost/api/attributed?api-version=42.0" );
 
                 // assert
                 response.StatusCode.Should().Be( BadRequest );
+                response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+                response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
             }
         }
 
@@ -121,13 +123,15 @@
         public async Task select_best_candidate_should_return_400_for_attributeX2Dbased_controller_with_bad_version()
         {
             // arrange
-            using ( var server = new WebServer() )
+            using ( var server = new WebServer( options => options.ReportApiVersions = true ) )
             {
                 // act
                 var response = await server.Client.GetAsync( "http://localhost/api/attributed?api-version=2016-06-32" );
 
                 // assert
                 response.StatusCode.Should().Be( BadRequest );
+                response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+                response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
             }
         }
 
@@ -135,13 +139,15 @@
         public async Task select_best_candidate_should_return_400_for_unmatchedX2C_conventionX2Dbased_controller_version()
         {
             // arrange
-            using ( var server = new WebServer( setupRoutes: routes => routes.MapRoute( "default", "api/{controller}/{action=Get}/{id?}" ) ) )
+            using ( var server = new WebServer( options => options.ReportApiVersions = true, routes => routes.MapRoute( "default", "api/{controller}/{action=Get}/{id?}" ) ) )
             {
                 // act
                 var response = await server.Client.GetAsync( "http://localhost/api/test?api-version=4.0" );
 
                 // assert
                 response.StatusCode.Should().Be( BadRequest );
+                response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0" );
+                response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "1.8, 1.9" );
             }
         }
 
@@ -149,13 +155,15 @@
         public async Task select_best_candidate_should_return_400_for_conventionX2Dbased_controller_with_bad_version()
         {
             // arrange
-            using ( var server = new WebServer( setupRoutes: routes => routes.MapRoute( "default", "api/{controller}/{action=Get}/{id?}" ) ) )
+            using ( var server = new WebServer( options => options.ReportApiVersions = true, routes => routes.MapRoute( "default", "api/{controller}/{action=Get}/{id?}" ) ) )
             {
                 // act
                 var response = await server.Client.GetAsync( "http://localhost/api/test?api-version=2016-06-32" );
 
                 // assert
                 response.StatusCode.Should().Be( BadRequest );
+                response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0" );
+                response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "1.8, 1.9" );
             }
         }
 
@@ -181,13 +189,15 @@
             // arrange
             var request = new HttpRequestMessage( Post, "api/attributed?api-version=1.0" );
 
-            using ( var server = new WebServer() )
+            using ( var server = new WebServer( options => options.ReportApiVersions = true ) )
             {
                 // act
                 var response = await server.Client.SendAsync( request );
 
                 // assert
                 response.StatusCode.Should().Be( MethodNotAllowed );
+                response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0, 3.0, 4.0" );
+                response.Headers.GetValues( "api-deprecated-versions" ).Single().Should().Be( "3.0-Alpha" );
             }
         }
 


### PR DESCRIPTION
Refactors the internal mechanics for reporting API versions into the IReportApiVersions interface. This service can be requested or changed through dependency injection. This change will allow the SDK to report API versions in both the matched, and now unmatched, cases. Resolves #187.