### PR TITLE
Added ability to look for lower version implemtation

### DIFF
--- a/src/Common/Versioning/ApiVersioningOptions.cs
+++ b/src/Common/Versioning/ApiVersioningOptions.cs
@@ -5,7 +5,6 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
 #endif
 {
     using Conventions;
-    using System;
     using System.Diagnostics.Contracts;
 #if WEBAPI
     using static Microsoft.Web.Http.Versioning.ApiVersionReader;
@@ -27,7 +26,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiVersioningOptions"/> class.
         /// </summary>
-        public ApiVersioningOptions() => apiVersionSelector = new DefaultApiVersionSelector( this );
+        public ApiVersioningOptions( ) => apiVersionSelector = new DefaultApiVersionSelector( this );
 
         /// <summary>
         /// Gets or sets a value indicating whether requests report the service API version compatibility
@@ -56,11 +55,12 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// <remarks>When a default API version is assumed, the version used is based up the
         /// result of the <see cref="IApiVersionSelector.SelectVersion"/> method.</remarks>
         public bool AssumeDefaultVersionWhenUnspecified { get; set; }
-        
+
         /// <summary>
-        /// Set tu <c>true</c> if lower version of API should be included when using versioning inheritance.
+        /// Gets or sets a value indicating whether the versioning should look fow lower versions implemtations.
         /// </summary>
-        public bool LookForLowerVesions {get;set;}
+        /// <value><c>true</c> if lower version of API should be included when using versioning inheritance.</value>
+        public bool LookForLowerVersions { get; set; }
 
         /// <summary>
         /// Gets or sets the default API version applied to services that do not have explicit versions.

--- a/src/Common/Versioning/ApiVersioningOptions.cs
+++ b/src/Common/Versioning/ApiVersioningOptions.cs
@@ -56,6 +56,11 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
         /// <remarks>When a default API version is assumed, the version used is based up the
         /// result of the <see cref="IApiVersionSelector.SelectVersion"/> method.</remarks>
         public bool AssumeDefaultVersionWhenUnspecified { get; set; }
+        
+        /// <summary>
+        /// Set tu <c>true</c> if lower version of API should be included when using versioning inheritance.
+        /// </summary>
+        public bool LookForLowerVesions {get;set;}
 
         /// <summary>
         /// Gets or sets the default API version applied to services that do not have explicit versions.

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/DirectRouteControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/DirectRouteControllerSelector.cs
@@ -52,6 +52,23 @@
 
             var versionedController = GetVersionedController( aggregator, requestedVersion );
 
+           var versionedController = GetVersionedController( aggregator, requestedVersion );
+
+            if ( versionedController == null )
+            {
+                if(options.LookForLowerVesions && requestedVersion.MajorVersion.HasValue)
+                {
+                    for ( int i = requestedVersion.MajorVersion.Value - 1; i > 0; i-- )
+                    {
+                        versionedController = GetVersionedController( aggregator, new ApiVersion( i, 0 ) );
+                        if ( versionedController != null )
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
             if ( versionedController == null )
             {
                 return result;

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/DirectRouteControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/DirectRouteControllerSelector.cs
@@ -13,16 +13,20 @@
 
     sealed class DirectRouteControllerSelector : ControllerSelector
     {
-        internal DirectRouteControllerSelector( ApiVersioningOptions options ) : base( options ) { }
+        private ApiVersioningOptions options;
+        internal DirectRouteControllerSelector( ApiVersioningOptions options ) : base( options )
+        {
+            this.options = options;
+        }
 
         internal override ControllerSelectionResult SelectController( ApiVersionControllerAggregator aggregator )
         {
             Contract.Requires( aggregator != null );
-            Contract.Ensures( Contract.Result<ControllerSelectionResult>() != null );
+            Contract.Ensures( Contract.Result<ControllerSelectionResult>( ) != null );
 
             var request = aggregator.Request;
             var requestedVersion = aggregator.RequestedApiVersion;
-            var result = new ControllerSelectionResult()
+            var result = new ControllerSelectionResult( )
             {
                 HasCandidates = aggregator.HasAttributeBasedRoutes,
                 RequestedVersion = requestedVersion,
@@ -52,11 +56,9 @@
 
             var versionedController = GetVersionedController( aggregator, requestedVersion );
 
-           var versionedController = GetVersionedController( aggregator, requestedVersion );
-
             if ( versionedController == null )
             {
-                if(options.LookForLowerVesions && requestedVersion.MajorVersion.HasValue)
+                if ( options.LookForLowerVersions && requestedVersion.MajorVersion.HasValue )
                 {
                     for ( int i = requestedVersion.MajorVersion.Value - 1; i > 0; i-- )
                     {
@@ -79,7 +81,7 @@
                 throw CreateAmbiguousControllerException( new[] { versionNeutralController, versionedController } );
             }
 
-            request.ApiVersionProperties().ApiVersion = requestedVersion;
+            request.ApiVersionProperties( ).ApiVersion = requestedVersion;
             result.RequestedVersion = requestedVersion;
             result.Controller = versionedController;
 
@@ -93,16 +95,16 @@
 
             HttpControllerDescriptor controllerDescriptor = null;
 
-            using ( var iterator = directRouteCandidates.Where( c => c.ActionDescriptor.IsApiVersionNeutral() ).GetEnumerator() )
+            using ( var iterator = directRouteCandidates.Where( c => c.ActionDescriptor.IsApiVersionNeutral( ) ).GetEnumerator( ) )
             {
-                if ( !iterator.MoveNext() )
+                if ( !iterator.MoveNext( ) )
                 {
                     return controllerDescriptor;
                 }
 
                 controllerDescriptor = iterator.Current.ActionDescriptor.ControllerDescriptor;
 
-                while ( iterator.MoveNext() )
+                while ( iterator.MoveNext( ) )
                 {
                     var candidate = iterator.Current;
 
@@ -126,7 +128,7 @@
 
             if ( directRouteCandidates.Length == 1 )
             {
-                if ( !controller.GetDeclaredApiVersions().Contains( requestedVersion ) )
+                if ( !controller.GetDeclaredApiVersions( ).Contains( requestedVersion ) )
                 {
                     return null;
                 }
@@ -139,7 +141,7 @@
                 }
             }
 
-            if ( !controller.HasApiVersionInfo() )
+            if ( !controller.HasApiVersionInfo( ) )
             {
                 controller.SetApiVersionModel( aggregator.AllVersions );
             }
@@ -156,19 +158,19 @@
             var controllerDescriptor = default( HttpControllerDescriptor );
             var matches = from candidate in directRouteCandidates
                           let controller = candidate.ActionDescriptor.ControllerDescriptor
-                          where controller.GetDeclaredApiVersions().Contains( requestedVersion )
+                          where controller.GetDeclaredApiVersions( ).Contains( requestedVersion )
                           select controller;
 
-            using ( var iterator = matches.GetEnumerator() )
+            using ( var iterator = matches.GetEnumerator( ) )
             {
-                if ( !iterator.MoveNext() )
+                if ( !iterator.MoveNext( ) )
                 {
                     return null;
                 }
 
                 controllerDescriptor = iterator.Current;
 
-                while ( iterator.MoveNext() )
+                while ( iterator.MoveNext( ) )
                 {
                     if ( iterator.Current != controllerDescriptor )
                     {
@@ -186,14 +188,14 @@
         static Exception CreateAmbiguousControllerException( IEnumerable<HttpControllerDescriptor> candidates )
         {
             Contract.Requires( candidates != null );
-            Contract.Ensures( Contract.Result<Exception>() != null );
+            Contract.Ensures( Contract.Result<Exception>( ) != null );
 
             var set = new HashSet<Type>( candidates.Select( c => c.ControllerType ) );
-            var builder = new StringBuilder();
+            var builder = new StringBuilder( );
 
             foreach ( var type in set )
             {
-                builder.AppendLine();
+                builder.AppendLine( );
                 builder.Append( type.FullName );
             }
 


### PR DESCRIPTION
When using inheritance with versioning the endpoint from lower version are not visible, this will make it work.

https://github.com/Microsoft/aspnet-api-versioning/issues/142