### PR TITLE
Support URL Substitution in API Explorer

### DIFF
--- a/samples/aspnetcore/SwaggerSample/Startup.cs
+++ b/samples/aspnetcore/SwaggerSample/Startup.cs
@@ -45,7 +45,15 @@
         {
             // add the versioned api explorer, which also adds IApiVersionDescriptionProvider service
             // note: the specified format code will format the version as "'v'major[.minor][-status]"
-            services.AddMvcCore().AddVersionedApiExplorer( o => o.GroupNameFormat = "'v'VVV" );
+            services.AddMvcCore().AddVersionedApiExplorer(
+                options =>
+                {
+                    options.GroupNameFormat = "'v'VVV";
+
+                    // note: this option is only necessary when versioning by url segment. the SubstitutionFormat
+                    // can also be used to control the format of the API version in route templates
+                    options.SubstituteApiVersionInUrl = true;
+                } );
 
             services.AddMvc();
             services.AddApiVersioning( o => o.ReportApiVersions = true );

--- a/samples/aspnetcore/SwaggerSample/SwaggerDefaultValues.cs
+++ b/samples/aspnetcore/SwaggerSample/SwaggerDefaultValues.cs
@@ -18,6 +18,11 @@
         /// <param name="context">The current operation filter context.</param>
         public void Apply( Operation operation, OperationFilterContext context )
         {
+            if ( operation.Parameters == null )
+            {
+                return;
+            }
+
             // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/412
             // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/413
             foreach ( var parameter in operation.Parameters.OfType<NonBodyParameter>() )

--- a/samples/webapi/SwaggerODataWebApiSample/Startup.cs
+++ b/samples/webapi/SwaggerODataWebApiSample/Startup.cs
@@ -55,11 +55,19 @@ namespace Microsoft.Examples
             configuration.MapVersionedODataRoutes( "odata", routePrefix, models, ConfigureODataServices );
 
             // WHEN VERSIONING BY: url segment
-            // configuration.MapVersionedODataRoutes( "odata-bypath", "api/v{apiVersion}", models, ConfigureODataServices );
+            //configuration.MapVersionedODataRoutes( "odata-bypath", "api/v{apiVersion}", models, ConfigureODataServices );
 
             // add the versioned IApiExplorer and capture the strongly-typed implementation (e.g. ODataApiExplorer vs IApiExplorer)
             // note: the specified format code will format the version as "'v'major[.minor][-status]"
-            var apiExplorer = configuration.AddODataApiExplorer( o => o.GroupNameFormat = "'v'VVV" );
+            var apiExplorer = configuration.AddODataApiExplorer(
+                options =>
+                {
+                    options.GroupNameFormat = "'v'VVV";
+
+                    // note: this option is only necessary when versioning by url segment. the SubstitutionFormat
+                    // can also be used to control the format of the API version in route templates
+                    options.SubstituteApiVersionInUrl = true;
+                } );
 
             configuration.EnableSwagger(
                            "{apiVersion}/swagger",

--- a/samples/webapi/SwaggerWebApiSample/Startup.cs
+++ b/samples/webapi/SwaggerWebApiSample/Startup.cs
@@ -33,7 +33,15 @@ namespace Microsoft.Examples
 
             // add the versioned IApiExplorer and capture the strongly-typed implementation (e.g. VersionedApiExplorer vs IApiExplorer)
             // note: the specified format code will format the version as "'v'major[.minor][-status]"
-            var apiExplorer = configuration.AddVersionedApiExplorer( o => o.GroupNameFormat = "'v'VVV" );
+            var apiExplorer = configuration.AddVersionedApiExplorer(
+                options =>
+                {
+                    options.GroupNameFormat = "'v'VVV";
+
+                    // note: this option is only necessary when versioning by url segment. the SubstitutionFormat
+                    // can also be used to control the format of the API version in route templates
+                    options.SubstituteApiVersionInUrl = true;
+                } );
 
             configuration.EnableSwagger(
                             "{apiVersion}/swagger",

--- a/src/Common.ApiExplorer/ApiExplorerOptions.cs
+++ b/src/Common.ApiExplorer/ApiExplorerOptions.cs
@@ -26,6 +26,26 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         public string GroupNameFormat { get; set; }
 
         /// <summary>
+        /// Gets or sets the format used to format the API version value substituted in route templates.
+        /// </summary>
+        /// <value>The string format used to format an <see cref="ApiVersion">API version</see>
+        /// in a route template. The default value is "VVV", which formats the major version number
+        /// and optional minor version.</value>
+        /// <remarks>For information about API version formatting, review <see cref="ApiVersionFormatProvider"/>
+        /// as well as the <see cref="ApiVersion.ToString(string)"/> and <see cref="ApiVersion.ToString(string, IFormatProvider)"/>
+        /// methods.</remarks>
+        public string SubstitutionFormat { get; set; } = "VVV";
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the API version parameter should be substituted in route templates.
+        /// </summary>
+        /// <value>True if the API version parameter should be substituted in route templates; otherwise, false.
+        /// The default value is <c>false</c>.</value>
+        /// <remarks>Setting this property to <c>true</c> will also remove the API version parameter from the
+        /// corresponding API description.</remarks>
+        public bool SubstituteApiVersionInUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the default description used for API version parameters.
         /// </summary>
         /// <value>The default description for API version parameters. The default value

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>1.1.0</VersionPrefix>
-  <AssemblyVersion>1.1.0.0</AssemblyVersion>
+  <VersionPrefix>1.2.0</VersionPrefix>
+  <AssemblyVersion>1.2.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Web API Versioned API Explorer for OData v4.0</AssemblyTitle>
   <Description>The API Explorer for Microsoft ASP.NET Web API Versioning and OData v4.0.</Description>
@@ -12,11 +12,7 @@
  </PropertyGroup>
 
  <ItemGroup>
-  <ReleaseNotes Include="Fix convention-based 'key' parameter binding (#226)" />
-  <ReleaseNotes Include="Version-neutral actions exclude the API version parameter" />
-  <ReleaseNotes Include="Added full support for actions" />
-  <ReleaseNotes Include="Added full support for functions" />
-  <ReleaseNotes Include="Added support for partial types using EDM" />
+  <ReleaseNotes Include="Support substituting API version parameter in route templates (Issue 247)" />
  </ItemGroup>
 
  <ItemGroup>

--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>1.1.0</VersionPrefix>
-  <AssemblyVersion>1.1.0.0</AssemblyVersion>
+  <VersionPrefix>1.2.0</VersionPrefix>
+  <AssemblyVersion>1.2.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Web API Versioned API Explorer</AssemblyTitle>
   <Description>The API Explorer for Microsoft ASP.NET Web API Versioning.</Description>
@@ -12,7 +12,7 @@
  </PropertyGroup>
 
  <ItemGroup>
-  <ReleaseNotes Include="Version-neutral actions exclude the API version parameter" />
+  <ReleaseNotes Include="Support substituting API version parameter in route templates (Issue 247)" />
  </ItemGroup>
 
  <ItemGroup>

--- a/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/ApiVersionParameterDescriptionContext.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/ApiVersionParameterDescriptionContext.cs
@@ -249,7 +249,7 @@
 
                 foreach ( var otherParameter in otherParameters )
                 {
-                    if ( otherParameter.ModelMetadata.DataTypeName == nameof( ApiVersion ) )
+                    if ( otherParameter.ModelMetadata?.DataTypeName == nameof( ApiVersion ) )
                     {
                         collection.Remove( otherParameter );
                     }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.csproj
@@ -14,6 +14,7 @@
 
  <ItemGroup>
   <ReleaseNotes Include="Support substituting API version parameter in route templates (Issue 247)" />
+  <ReleaseNotes Include="Fix NullReferenceException when parameter without metadata is encountered (Issue 250)" />
  </ItemGroup>
 
  <ItemGroup>

--- a/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>2.1.0</VersionPrefix>
-  <AssemblyVersion>2.1.0.0</AssemblyVersion>
+  <VersionPrefix>2.2.0</VersionPrefix>
+  <AssemblyVersion>2.2.0.0</AssemblyVersion>
   <TargetFramework>netstandard2.0</TargetFramework>
   <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
   <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
@@ -13,7 +13,7 @@
  </PropertyGroup>
 
  <ItemGroup>
-  <ReleaseNotes Include="Version-neutral actions exclude the API version parameter" />
+  <ReleaseNotes Include="Support substituting API version parameter in route templates (Issue 247)" />
  </ItemGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Adds support to substitute the API versions in URLs from route templates in API descriptions generated by API Explorers. This change also contains a fix for a NullReferenceException when a parameter does not have model metadata (ASP.NET Core only).

Resolves #247. Fixes #250.