### PR TITLE
Fix API Version Reporting

### DIFF
--- a/src/Microsoft.AspNetCore.Mvc.Versioning/ReportApiVersionsAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/ReportApiVersionsAttribute.cs
@@ -30,12 +30,14 @@
         }
 
         /// <summary>
-        /// Reports the discovered service API versions for the given context after an action has executed.
+        /// Reports the discovered service API versions for the given context before an action has executed.
         /// </summary>
-        /// <param name="context">The <see cref="ActionExecutedContext">context</see> for the executed action.</param>
+        /// <param name="context">The <see cref="ActionExecutingContext">context</see> for the executing action.</param>
         /// <remarks>This method will write the "api-supported-versions" and "api-deprecated-versions" HTTP headers into the
-        /// response provided that there is a response and the executed action was not version-neutral.</remarks>
-        public override void OnActionExecuted( ActionExecutedContext context )
+        /// response provided the executing action is not version-neutral. This operation should be performed before the
+        /// action is executed instead of after as HTTP headers cannot be specified after the response body has started
+        /// streaming to the client.</remarks>
+        public override void OnActionExecuting( ActionExecutingContext context )
         {
             var response = context.HttpContext.Response;
 

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ActionDescriptorMatch.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ActionDescriptorMatch.cs
@@ -64,11 +64,11 @@
         /// <returns>True if the objects are equal; otherwise, false.</returns>
         public static bool operator ==( ActionDescriptorMatch match1, ActionDescriptorMatch match2 )
         {
-            if ( ReferenceEquals( match1, null ) )
+            if ( match1 is null )
             {
-                return ReferenceEquals( match2, null );
+                return match2 is null;
             }
-            else if ( ReferenceEquals( match2, null ) )
+            else if ( match2 is null )
             {
                 return false;
             }
@@ -84,11 +84,11 @@
         /// <returns>True if the objects are not equal; otherwise, false.</returns>
         public static bool operator !=( ActionDescriptorMatch match1, ActionDescriptorMatch match2 )
         {
-            if ( ReferenceEquals( match1, null ) )
+            if ( match1 is null )
             {
-                return !ReferenceEquals( match2, null );
+                return !( match2 is null );
             }
-            else if ( ReferenceEquals( match2, null ) )
+            else if ( match2 is null )
             {
                 return true;
             }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/ReportApiVersionsAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/ReportApiVersionsAttributeTest.cs
@@ -6,29 +6,33 @@
     using FluentAssertions;
     using Http;
     using Moq;
+    using System.Collections.Generic;
     using System.Linq;
     using Versioning;
     using Xunit;
 
     public class ReportApiVersionsAttributeTest
     {
-        static ActionExecutedContext CreateContext( ApiVersionModel model )
+        static ActionExecutingContext CreateContext( ApiVersionModel model )
         {
             var headers = new HeaderDictionary();
             var response = new Mock<HttpResponse>();
             var httpContext = new Mock<HttpContext>();
             var action = new ActionDescriptor();
             var actionContext = new ActionContext( httpContext.Object, new RouteData(), action  );
+            var filters = new IFilterMetadata[0];
+            var actionArguments = new Dictionary<string, object>();
+            var controller = default( object );
 
             response.SetupGet( r => r.Headers ).Returns( headers );
             httpContext.SetupGet( c => c.Response ).Returns( response.Object );
             action.SetProperty( model );
 
-            return new ActionExecutedContext( actionContext, new IFilterMetadata[0], null );
+            return new ActionExecutingContext( actionContext, filters, actionArguments, controller );
         }
 
         [Fact]
-        public void on_action_executed_should_add_version_headers()
+        public void on_action_executing_should_add_version_headers()
         {
             // arrange
             var supported = new[] { new ApiVersion( 1, 0 ), new ApiVersion( 2, 0 ) };
@@ -38,7 +42,7 @@
             var attribute = new ReportApiVersionsAttribute();
 
             // act
-            attribute.OnActionExecuted( context );
+            attribute.OnActionExecuting( context );
 
             // assert
             context.HttpContext.Response.Headers["api-supported-versions"].Single().Should().Be( "1.0, 2.0" );
@@ -53,7 +57,7 @@
             var attribute = new ReportApiVersionsAttribute();
 
             // act
-            attribute.OnActionExecuted( context );
+            attribute.OnActionExecuting( context );
 
 
             // assert


### PR DESCRIPTION
Fixes scenarios in ASP.NET Core where the API versions cannot be reported in the HTTP response headers because the response is already being written to the client.

Fixes #273. Fixes #290.