### PR TITLE
change odata route prefix to support api/version requests

### DIFF
--- a/samples/aspnetcore/ODataBasicSample/Controllers/OrdersController.cs
+++ b/samples/aspnetcore/ODataBasicSample/Controllers/OrdersController.cs
@@ -11,13 +11,11 @@
     public class OrdersController : ODataController
     {
         // GET ~/v1/orders
-        // GET ~/api/orders?api-version=1.0
         [ODataRoute]
         public IActionResult Get( ODataQueryOptions<Order> options ) =>
             Ok( new[] { new Order() { Id = 1, Customer = "Bill Mei" } } );
 
         // GET ~/v1/orders(1)
-        // GET ~/api/orders(1)?api-version=1.0
         [ODataRoute( "({id})" )]
         public IActionResult Get( [FromODataUri] int id, ODataQueryOptions<Order> options ) =>
             Ok( new Order() { Id = id, Customer = "Bill Mei" } );

--- a/samples/aspnetcore/ODataBasicSample/Controllers/People2Controller.cs
+++ b/samples/aspnetcore/ODataBasicSample/Controllers/People2Controller.cs
@@ -12,13 +12,11 @@
     public class People2Controller : ODataController
     {
         // GET ~/v3/people
-        // GET ~/api/people?api-version=3.0
         [ODataRoute]
         public IActionResult Get( ODataQueryOptions<Person> options ) =>
             Ok( new[] { new Person() { Id = 1, FirstName = "Bill", LastName = "Mei", Email = "bill.mei@somewhere.com", Phone = "555-555-5555" } } );
 
         // GET ~/v3/people(1)
-        // GET ~/api/people(1)?api-version=3.0
         [ODataRoute( "({id})" )]
         public IActionResult Get( [FromODataUri] int id, ODataQueryOptions<Person> options ) =>
             Ok( new Person() { Id = id, FirstName = "Bill", LastName = "Mei", Email = "bill.mei@somewhere.com", Phone = "555-555-5555" } );

--- a/samples/aspnetcore/ODataBasicSample/Controllers/PeopleController.cs
+++ b/samples/aspnetcore/ODataBasicSample/Controllers/PeopleController.cs
@@ -13,20 +13,17 @@
     {
         // GET ~/v1/people
         // GET ~/v2/people
-        // GET ~/api/people?api-version=[1.0|2.0]
         [ODataRoute]
         public IActionResult Get( ODataQueryOptions<Person> options ) =>
             Ok( new[] { new Person() { Id = 1, FirstName = "Bill", LastName = "Mei", Email = "bill.mei@somewhere.com", Phone = "555-555-5555" } } );
 
         // GET ~/v1/people(1)
         // GET ~/v2/people(1)
-        // GET ~/api/people(1)?api-version=[1.0|2.0]
         [ODataRoute( "({id})" )]
         public IActionResult Get( [FromODataUri] int id, ODataQueryOptions<Person> options ) =>
             Ok( new Person() { Id = id, FirstName = "Bill", LastName = "Mei", Email = "bill.mei@somewhere.com", Phone = "555-555-5555" } );
 
         // PATCH ~/v2/people(1)
-        // PATCH ~/api/people(1)?api-version=2.0
         [MapToApiVersion( "2.0" )]
         [ODataRoute( "({id})" )]
         public IActionResult Patch( [FromODataUri] int id, Delta<Person> delta, ODataQueryOptions<Person> options )

--- a/samples/aspnetcore/ODataBasicSample/Properties/launchSettings.json
+++ b/samples/aspnetcore/ODataBasicSample/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/People?api-version=1.0",
+      "launchUrl": "api/v1/People",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,7 +19,7 @@
     "BasicSample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000/api/People?api-version=1.0",
+      "launchUrl": "http://localhost:5000/api/v1/People",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/samples/aspnetcore/ODataBasicSample/Startup.cs
+++ b/samples/aspnetcore/ODataBasicSample/Startup.cs
@@ -42,7 +42,7 @@
         {
             loggerFactory.AddConsole( Configuration.GetSection( "Logging" ) );
             loggerFactory.AddDebug();
-            app.UseMvc( routeBuilder => routeBuilder.MapVersionedODataRoutes( "odata", "api", modelBuilder.GetEdmModels() ) );
+            app.UseMvc( routeBuilder => routeBuilder.MapVersionedODataRoutes( "odata", "api/v{apiVersion}", modelBuilder.GetEdmModels() ) );
         }
     }
 }


### PR DESCRIPTION
I was having an issue when trying to run the ODataBasicSample in the latest .Net Core with OData examples. When trying to query with `api/v1/people`, I would get a 404. I did some research and testing and made a simple change for the project to work when using the version in the path instead of in the query string.