### PR TITLE
Pre-Aggregate Web API Models

### DIFF
--- a/src/Common/Versioning/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Common/Versioning/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -12,8 +12,6 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
     /// </summary>
     public partial class ActionApiVersionConventionBuilderBase
     {
-        readonly HashSet<ApiVersion> mappedVersions = new HashSet<ApiVersion>();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ActionApiVersionConventionBuilderBase"/> class.
         /// </summary>
@@ -23,6 +21,6 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
         /// Gets the collection of API versions mapped to the current action.
         /// </summary>
         /// <value>A <see cref="ICollection{T}">collection</see> of mapped <see cref="ApiVersion">API versions</see>.</value>
-        protected ICollection<ApiVersion> MappedVersions => mappedVersions;
+        protected ICollection<ApiVersion> MappedVersions { get; } = new HashSet<ApiVersion>();
     }
 }

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/System.Web.Http/Controllers/HttpControllerDescriptorExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/System.Web.Http/Controllers/HttpControllerDescriptorExtensions.cs
@@ -5,35 +5,8 @@
 
     static class HttpControllerDescriptorExtensions
     {
-        const string RelatedControllerCandidatesKey = "MS_RelatedControllerCandidates";
-
         internal static IEnumerable<HttpControllerDescriptor> AsEnumerable( this HttpControllerDescriptor controllerDescriptor )
         {
-            if ( controllerDescriptor.Properties.TryGetValue( RelatedControllerCandidatesKey, out object value ) )
-            {
-                if ( value is IEnumerable<HttpControllerDescriptor> relatedCandidates )
-                {
-                    using ( var relatedControllerDescriptors = relatedCandidates.GetEnumerator() )
-                    {
-                        if ( relatedControllerDescriptors.MoveNext() )
-                        {
-                            yield return controllerDescriptor;
-
-                            do
-                            {
-                                if ( relatedControllerDescriptors.Current != controllerDescriptor )
-                                {
-                                    yield return relatedControllerDescriptors.Current;
-                                }
-                            }
-                            while ( relatedControllerDescriptors.MoveNext() );
-
-                            yield break;
-                        }
-                    }
-                }
-            }
-
             if ( controllerDescriptor is IEnumerable<HttpControllerDescriptor> groupedControllerDescriptors )
             {
                 foreach ( var groupedControllerDescriptor in groupedControllerDescriptors )

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/System.Web.Http/HttpRouteCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/System.Web.Http/HttpRouteCollectionExtensions.cs
@@ -1,10 +1,7 @@
 ﻿namespace System.Web.Http
 {
-    using System.Collections.Generic;
     using System.Diagnostics.Contracts;
-    using System.Reflection;
     using System.Web.Http.Routing;
-    using static System.Reflection.BindingFlags;
 
     static class HttpRouteCollectionExtensions
     {
@@ -13,9 +10,7 @@
             Contract.Requires( routes != null );
             Contract.Requires( route != null );
 
-            var items = CopyRouteEntries( routes );
-
-            foreach ( var item in items )
+            foreach ( var item in routes.ToDictionary() )
             {
                 if ( Equals( item.Value, route ) )
                 {
@@ -24,62 +19,6 @@
             }
 
             return null;
-        }
-
-        static KeyValuePair<string, IHttpRoute>[] CopyRouteEntries( HttpRouteCollection routes )
-        {
-            Contract.Requires( routes != null );
-            Contract.Ensures( Contract.Result<KeyValuePair<string, IHttpRoute>[]>() != null );
-
-            var items = new KeyValuePair<string, IHttpRoute>[routes.Count];
-
-            try
-            {
-                routes.CopyTo( items, 0 );
-            }
-            catch ( NotSupportedException ) when ( routes.GetType().FullName == "System.Web.Http.WebHost.Routing.HostedHttpRouteCollection" )
-            {
-                var keys = GetRouteKeys( routes );
-
-                for ( var i = 0; i < keys.Count; i++ )
-                {
-                    var key = keys[i];
-                    var route = routes[key];
-
-                    items[i] = new KeyValuePair<string, IHttpRoute>( key, route );
-                }
-            }
-
-            return items;
-        }
-
-        static IReadOnlyList<string> GetRouteKeys( HttpRouteCollection routes )
-        {
-            Contract.Requires( routes != null );
-            Contract.Ensures( Contract.Result<IReadOnlyList<string>>() != null );
-
-            var collection = GetKeys( routes );
-            var keys = new string[collection.Count];
-
-            collection.CopyTo( keys, 0 );
-
-            return keys;
-        }
-
-        static ICollection<string> GetKeys( HttpRouteCollection routes )
-        {
-            Contract.Requires( routes != null );
-            Contract.Ensures( Contract.Result<ICollection<string>>() != null );
-
-            // HACK: System.Web.Routing.RouteCollection doesn't expose the names associated with registered routes. The
-            // HostedHttpRouteCollection could have provided an adapter to support it, but didn't. Instead, it always throws
-            // NotSupportedException for the HttpRouteCollection.CopyTo method. This only happens when hosted on IIS. The
-            // only way to get the keys is use reflection to poke at the underlying dictionary.
-            var routeCollection = routes.GetType().GetField( "_routeCollection", Instance | NonPublic ).GetValue( routes );
-            var dictionary = routeCollection.GetType().GetField( "_namedMap", Instance | NonPublic ).GetValue( routeCollection );
-            var keys = (ICollection<string>) dictionary.GetType().GetRuntimeProperty( "Keys" ).GetValue( dictionary, null );
-
-            return keys;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Versioning/System.Web.Http/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/System.Web.Http/HttpConfigurationExtensions.cs
@@ -610,11 +610,8 @@
             Arg.NotNull( configuration, nameof( configuration ) );
             Arg.NotNull( apiVersion, nameof( apiVersion ) );
 
-            var allRoutes = configuration.Routes;
-            var routes = new KeyValuePair<string, IHttpRoute>[allRoutes.Count];
+            var routes = configuration.Routes.ToDictionary();
             var containers = configuration.GetRootContainerMappings();
-
-            allRoutes.CopyTo( routes, 0 );
 
             foreach ( var route in routes )
             {

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/ControllerSelector.cs
@@ -17,6 +17,6 @@
 
         protected IApiVersionSelector ApiVersionSelector => options.ApiVersionSelector;
 
-        internal abstract ControllerSelectionResult SelectController( ApiVersionControllerAggregator aggregator );
+        internal abstract ControllerSelectionResult SelectController( ControllerSelectionContext context );
     }
 }

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/DirectRouteControllerSelector.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/DirectRouteControllerSelector.cs
@@ -15,16 +15,16 @@
     {
         internal DirectRouteControllerSelector( ApiVersioningOptions options ) : base( options ) { }
 
-        internal override ControllerSelectionResult SelectController( ApiVersionControllerAggregator aggregator )
+        internal override ControllerSelectionResult SelectController( ControllerSelectionContext context )
         {
-            Contract.Requires( aggregator != null );
+            Contract.Requires( context != null );
             Contract.Ensures( Contract.Result<ControllerSelectionResult>() != null );
 
-            var request = aggregator.Request;
-            var requestedVersion = aggregator.RequestedApiVersion;
+            var request = context.Request;
+            var requestedVersion = context.RequestedApiVersion;
             var result = new ControllerSelectionResult()
             {
-                HasCandidates = aggregator.HasAttributeBasedRoutes,
+                HasCandidates = context.HasAttributeBasedRoutes,
                 RequestedVersion = requestedVersion,
             };
 
@@ -33,7 +33,7 @@
                 return result;
             }
 
-            var versionNeutralController = result.Controller = GetVersionNeutralController( aggregator.DirectRouteCandidates );
+            var versionNeutralController = result.Controller = GetVersionNeutralController( context.DirectRouteCandidates );
 
             if ( requestedVersion == null )
             {
@@ -42,7 +42,7 @@
                     return result;
                 }
 
-                requestedVersion = ApiVersionSelector.SelectVersion( request, aggregator.AllVersions );
+                requestedVersion = ApiVersionSelector.SelectVersion( request, context.AllVersions );
 
                 if ( requestedVersion == null )
                 {
@@ -50,7 +50,7 @@
                 }
             }
 
-            var versionedController = GetVersionedController( aggregator, requestedVersion );
+            var versionedController = GetVersionedController( context, requestedVersion );
 
             if ( versionedController == null )
             {
@@ -99,12 +99,12 @@
             return controllerDescriptor;
         }
 
-        static HttpControllerDescriptor GetVersionedController( ApiVersionControllerAggregator aggregator, ApiVersion requestedVersion )
+        static HttpControllerDescriptor GetVersionedController( ControllerSelectionContext context, ApiVersion requestedVersion )
         {
-            Contract.Requires( aggregator != null );
+            Contract.Requires( context != null );
             Contract.Requires( requestedVersion != null );
 
-            var directRouteCandidates = aggregator.DirectRouteCandidates;
+            var directRouteCandidates = context.DirectRouteCandidates;
             var controller = directRouteCandidates[0].ActionDescriptor.ControllerDescriptor;
 
             if ( directRouteCandidates.Length == 1 )
@@ -120,11 +120,6 @@
                 {
                     return null;
                 }
-            }
-
-            if ( !controller.HasApiVersionInfo() )
-            {
-                controller.SetApiVersionModel( aggregator.AllVersions );
             }
 
             return controller;

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpControllerTypeCache.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpControllerTypeCache.cs
@@ -6,7 +6,7 @@
     using System.Linq;
     using System.Reflection;
     using System.Web.Http;
-    using System.Web.Http.Dispatcher;
+    using static System.Web.Http.Dispatcher.DefaultHttpControllerSelector;
 
     sealed class HttpControllerTypeCache
     {
@@ -36,11 +36,39 @@
                 return attribute.Name;
             }
 
-            // use standard convention for the controller name
+            // use standard convention for the controller name (ex: ValuesController -> Values)
             var name = type.Name;
-            var suffixLength = DefaultHttpControllerSelector.ControllerSuffix.Length;
+            var suffixLength = ControllerSuffix.Length;
 
-            return name.Substring( 0, name.Length - suffixLength );
+            name = name.Substring( 0, name.Length - suffixLength );
+
+            // trim trailing numbers to enable grouping by convention (ex: Values1Controller -> Values, Values2Controller -> Values)
+            return TrimTrailingNumbers( name );
+        }
+
+        static string TrimTrailingNumbers( string name )
+        {
+            if ( string.IsNullOrEmpty( name ) )
+            {
+                return name;
+            }
+
+            var last = name.Length - 1;
+
+            for ( var i = last; i >= 0; i-- )
+            {
+                if ( !char.IsNumber( name[i] ) )
+                {
+                    if ( i < last )
+                    {
+                        return name.Substring( 0, i + 1 );
+                    }
+
+                    return name;
+                }
+            }
+
+            return name;
         }
 
         Dictionary<string, ILookup<string, Type>> InitializeCache()

--- a/src/Microsoft.AspNet.WebApi.Versioning/System.Web.Http/HttpRouteCollectionExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/System.Web.Http/HttpRouteCollectionExtensions.cs
@@ -1,0 +1,104 @@
+﻿namespace System.Web.Http
+{
+    using Microsoft;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Reflection;
+    using System.Web.Http.Routing;
+    using static System.Reflection.BindingFlags;
+
+    /// <summary>
+    /// Provides extension methods for the <see cref="HttpRouteCollection"/>.
+    /// </summary>
+    public static class HttpRouteCollectionExtensions
+    {
+        /// <summary>
+        /// Returns the route collection as a read-only dictionary mapping configured names to routes.
+        /// </summary>
+        /// <param name="routes">The <see cref="HttpRouteCollection">route collection</see> to convert.</param>
+        /// <returns>A new <see cref="IReadOnlyDictionary{TKey, TValue}">read-only dictonary</see> of
+        /// <see cref="IHttpRoute">routes</see> mapped to their name.</returns>
+        public static IReadOnlyDictionary<string, IHttpRoute> ToDictionary( this HttpRouteCollection routes )
+        {
+            Arg.NotNull( routes, nameof( routes ) );
+            Contract.Ensures( Contract.Result<IReadOnlyDictionary<string, IHttpRoute>>() != null );
+
+            const string HostedHttpRouteCollection = "System.Web.Http.WebHost.Routing.HostedHttpRouteCollection";
+
+            try
+            {
+                return routes.CopyToDictionary();
+            }
+            catch ( NotSupportedException ) when ( routes.GetType().FullName == HostedHttpRouteCollection )
+            {
+                return routes.BuildDictionaryFromKeys();
+            }
+        }
+
+        static IReadOnlyDictionary<string, IHttpRoute> CopyToDictionary( this HttpRouteCollection routes )
+        {
+            Contract.Requires( routes != null );
+            Contract.Ensures( Contract.Result<IReadOnlyDictionary<string, IHttpRoute>>() != null );
+
+            var items = new KeyValuePair<string, IHttpRoute>[routes.Count];
+
+            routes.CopyTo( items, 0 );
+
+            var dictionary = new Dictionary<string, IHttpRoute>( routes.Count, StringComparer.OrdinalIgnoreCase );
+
+            for ( var i = 0; i < items.Length; i++ )
+            {
+                var item = items[i];
+                dictionary[item.Key] = item.Value;
+            }
+
+            return dictionary;
+        }
+
+        static IReadOnlyDictionary<string, IHttpRoute> BuildDictionaryFromKeys( this HttpRouteCollection routes )
+        {
+            Contract.Requires( routes != null );
+            Contract.Ensures( Contract.Result<IReadOnlyDictionary<string, IHttpRoute>>() != null );
+
+            var keys = routes.Keys();
+            var dictionary = new Dictionary<string, IHttpRoute>( routes.Count, StringComparer.OrdinalIgnoreCase );
+
+            for ( var i = 0; i < keys.Count; i++ )
+            {
+                var key = keys[i];
+                dictionary[key] = routes[key];
+            }
+
+            return dictionary;
+        }
+
+        static IReadOnlyList<string> Keys( this HttpRouteCollection routes )
+        {
+            Contract.Requires( routes != null );
+            Contract.Ensures( Contract.Result<IReadOnlyList<string>>() != null );
+
+            var collection = GetDictionaryKeys( routes );
+            var keys = new string[collection.Count];
+
+            collection.CopyTo( keys, 0 );
+
+            return keys;
+        }
+
+        static ICollection<string> GetDictionaryKeys( HttpRouteCollection routes )
+        {
+            Contract.Requires( routes != null );
+            Contract.Ensures( Contract.Result<ICollection<string>>() != null );
+
+            // HACK: System.Web.Routing.RouteCollection doesn't expose the names associated with registered routes. The
+            // HostedHttpRouteCollection could have provided an adapter to support it, but didn't. Instead, it always throws
+            // NotSupportedException for the HttpRouteCollection.CopyTo method. This only happens when hosted on IIS. The
+            // only way to get the keys is use reflection to poke at the underlying dictionary.
+            var routeCollection = routes.GetType().GetField( "_routeCollection", Instance | NonPublic ).GetValue( routes );
+            var dictionary = routeCollection.GetType().GetField( "_namedMap", Instance | NonPublic ).GetValue( routeCollection );
+            var keys = (ICollection<string>) dictionary.GetType().GetRuntimeProperty( "Keys" ).GetValue( dictionary, null );
+
+            return keys;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/TupleExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/TupleExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.Web.Http
+{
+    using System;
+    using System.Diagnostics.Contracts;
+
+    internal static class TupleExtensions
+    {
+        public static void Deconstruct<T1, T2, T3, T4>( this Tuple<T1, T2, T3, T4> tuple, out T1 item1, out T2 item2, out T3 item3, out T4 item4 )
+        {
+            Contract.Requires( tuple != null );
+
+            item1 = tuple.Item1;
+            item2 = tuple.Item2;
+            item3 = tuple.Item3;
+            item4 = tuple.Item4;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/ApiVersionModel.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/ApiVersionModel.cs
@@ -44,27 +44,6 @@
             }
         }
 
-        internal ApiVersionModel( HttpControllerDescriptor controllerDescriptor, ApiVersionModel aggregatedVersions )
-        {
-            Contract.Requires( controllerDescriptor != null );
-            Contract.Requires( aggregatedVersions != null );
-
-            if ( IsApiVersionNeutral = controllerDescriptor.GetCustomAttributes<IApiVersionNeutral>( false ).Any() )
-            {
-                declaredVersions = emptyVersions;
-                implementedVersions = emptyVersions;
-                supportedVersions = emptyVersions;
-                deprecatedVersions = emptyVersions;
-            }
-            else
-            {
-                declaredVersions = new Lazy<IReadOnlyList<ApiVersion>>( () => GetDeclaredControllerApiVersions( controllerDescriptor ) );
-                implementedVersions = aggregatedVersions.implementedVersions;
-                supportedVersions = aggregatedVersions.supportedVersions;
-                deprecatedVersions = aggregatedVersions.deprecatedVersions;
-            }
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiVersionModel"/> class.
         /// </summary>
@@ -73,7 +52,9 @@
         {
             Arg.NotNull( actionDescriptor, nameof( actionDescriptor ) );
 
-            if ( IsApiVersionNeutral = actionDescriptor.ControllerDescriptor.GetCustomAttributes<IApiVersionNeutral>( false ).Any() )
+            var controllerModel = actionDescriptor.ControllerDescriptor.GetApiVersionModel();
+
+            if ( IsApiVersionNeutral = controllerModel.IsApiVersionNeutral )
             {
                 declaredVersions = emptyVersions;
                 implementedVersions = emptyVersions;
@@ -83,9 +64,9 @@
             else
             {
                 declaredVersions = new Lazy<IReadOnlyList<ApiVersion>>( actionDescriptor.GetCustomAttributes<IApiVersionProvider>( false ).GetImplementedApiVersions );
-                implementedVersions = declaredVersions;
-                supportedVersions = new Lazy<IReadOnlyList<ApiVersion>>( actionDescriptor.GetCustomAttributes<IApiVersionProvider>( false ).GetSupportedApiVersions );
-                deprecatedVersions = new Lazy<IReadOnlyList<ApiVersion>>( actionDescriptor.GetCustomAttributes<IApiVersionProvider>( false ).GetDeprecatedApiVersions );
+                implementedVersions = new Lazy<IReadOnlyList<ApiVersion>>( () => controllerModel.ImplementedApiVersions );
+                supportedVersions = new Lazy<IReadOnlyList<ApiVersion>>( () => controllerModel.SupportedApiVersions );
+                deprecatedVersions = new Lazy<IReadOnlyList<ApiVersion>>( () => controllerModel.DeprecatedApiVersions );
             }
         }
 

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/ApplicationModels/ModelExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/ApplicationModels/ModelExtensions.cs
@@ -1,8 +1,6 @@
 ﻿namespace Microsoft.AspNetCore.Mvc.ApplicationModels
 {
     using System;
-    using System.Linq;
-    using Microsoft.AspNetCore.Mvc.Versioning;
 
     /// <summary>
     /// Provides extension methods for <see cref="ApplicationModel">application models</see>, <see cref="ControllerModel">controller models</see>,
@@ -17,7 +15,7 @@
         /// <typeparam name="T">The <see cref="Type">type</see> and key of the property.</typeparam>
         /// <param name="controller">The <see cref="ControllerModel">model</see> to get the property from.</param>
         /// <returns>The property value of <typeparamref name="T"/> or its default value.</returns>
-        public static T GetProperty<T>( this ControllerModel controller ) where T : class
+        public static T GetProperty<T>( this ControllerModel controller )
         {
             Arg.NotNull( controller, nameof( controller ) );
             return controller.Properties.GetOrDefault( typeof( T ), default( T ) );
@@ -29,7 +27,7 @@
         /// <typeparam name="T">The <see cref="Type">type</see> and key of the property.</typeparam>
         /// <param name="controller">The <see cref="ControllerModel">model</see> to set the property for.</param>
         /// <param name="value">The property value to set.</param>
-        public static void SetProperty<T>( this ControllerModel controller, T value ) where T : class
+        public static void SetProperty<T>( this ControllerModel controller, T value )
         {
             Arg.NotNull( controller, nameof( controller ) );
             controller.Properties.SetOrRemove( typeof( T ), value );
@@ -41,7 +39,7 @@
         /// <typeparam name="T">The <see cref="Type">type</see> and key of the property.</typeparam>
         /// <param name="action">The <see cref="ActionModel">model</see> to get the property from.</param>
         /// <returns>The property value of <typeparamref name="T"/> or its default value.</returns>
-        public static T GetProperty<T>( this ActionModel action ) where T : class
+        public static T GetProperty<T>( this ActionModel action )
         {
             Arg.NotNull( action, nameof( action ) );
             return action.Properties.GetOrDefault( typeof( T ), default( T ) );
@@ -53,10 +51,14 @@
         /// <typeparam name="T">The <see cref="Type">type</see> and key of the property.</typeparam>
         /// <param name="action">The <see cref="ActionModel">model</see> to set the property for.</param>
         /// <param name="value">The property value to set.</param>
-        public static void SetProperty<T>( this ActionModel action, T value ) where T : class
+        public static void SetProperty<T>( this ActionModel action, T value )
         {
             Arg.NotNull( action, nameof( action ) );
             action.Properties.SetOrRemove( typeof( T ), value );
         }
+
+#pragma warning disable CA1801 // Review unused parameters; intentional for type parameter
+        internal static void RemoveProperty<T>( this ActionModel action, T value ) => action.Properties.Remove( typeof( T ) );
+#pragma warning restore CA1801
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/CollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/CollectionExtensions.cs
@@ -15,11 +15,11 @@
             return dictionary.TryGetValue( key, out TValue value ) ? value : defaultValue();
         }
 
-        internal static void SetOrRemove<TKey, TValue>( this IDictionary<TKey, object> dictionary, TKey key, TValue value ) where TValue : class
+        internal static void SetOrRemove<TKey, TValue>( this IDictionary<TKey, object> dictionary, TKey key, TValue value )
         {
             Contract.Requires( dictionary != null );
 
-            if ( value == null )
+            if ( value == default && default( TValue ) == null )
             {
                 dictionary.Remove( key );
             }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -25,10 +25,10 @@
                                      select version );
 
             var (supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions) =
-                actionModel.GetProperty<(IEnumerable<ApiVersion>,
-                                         IEnumerable<ApiVersion>,
-                                         IEnumerable<ApiVersion>,
-                                         IEnumerable<ApiVersion>)>();
+                actionModel.GetProperty<Tuple<IEnumerable<ApiVersion>,
+                                              IEnumerable<ApiVersion>,
+                                              IEnumerable<ApiVersion>,
+                                              IEnumerable<ApiVersion>>>();
 
             var versionModel = new ApiVersionModel(
                 declaredVersions: MappedVersions,

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ActionApiVersionConventionBuilderBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ActionApiVersionConventionBuilderBase.cs
@@ -1,14 +1,9 @@
-﻿#pragma warning disable SA1200 // Using directives should be placed correctly; false positive - required for inner, short-hand type aliasing
-using System;
-using System.Collections.Generic;
-#pragma warning restore SA1200
-
-namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
+﻿namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
 {
     using Microsoft.AspNetCore.Mvc.ApplicationModels;
     using System;
+    using System.Collections.Generic;
     using System.Linq;
-    using ControllerVersionInfo = System.Tuple<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>>;
 
     /// <content>
     /// Provides additional implementation specific to Microsoft ASP.NET Core.
@@ -29,13 +24,18 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                                      from version in provider.Versions
                                      select version );
 
-            var controllerVersionInfo = actionModel.GetProperty<ControllerVersionInfo>();
+            var (supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions) =
+                actionModel.GetProperty<(IEnumerable<ApiVersion>,
+                                         IEnumerable<ApiVersion>,
+                                         IEnumerable<ApiVersion>,
+                                         IEnumerable<ApiVersion>)>();
+
             var versionModel = new ApiVersionModel(
                 declaredVersions: MappedVersions,
-                supportedVersions: controllerVersionInfo.Item1,
-                deprecatedVersions: controllerVersionInfo.Item2,
-                advertisedVersions: controllerVersionInfo.Item3,
-                deprecatedAdvertisedVersions: controllerVersionInfo.Item4 );
+                supportedVersions,
+                deprecatedVersions,
+                advertisedVersions,
+                deprecatedAdvertisedVersions );
 
             actionModel.SetProperty( versionModel );
         }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ControllerApiVersionConventionBuilderBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ControllerApiVersionConventionBuilderBase.cs
@@ -42,7 +42,7 @@
             }
         }
 
-        (IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>) ApplyControllerConventions( ControllerModel controllerModel )
+        Tuple<IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>> ApplyControllerConventions( ControllerModel controllerModel )
         {
             Contract.Requires( controllerModel != null );
 
@@ -57,7 +57,7 @@
                 controllerModel.SetProperty( new ApiVersionModel( VersionNeutral, supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions ) );
             }
 
-            return (supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions);
+            return Tuple.Create( supportedVersions.AsEnumerable(), deprecatedVersions.AsEnumerable(), advertisedVersions.AsEnumerable(), deprecatedAdvertisedVersions.AsEnumerable() );
         }
 
         void MergeControllerAttributesWithConventions( ControllerModel controllerModel )
@@ -97,7 +97,7 @@
                                                     select version );
         }
 
-        void ApplyActionConventions( ControllerModel controller, (IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>) controllerVersionInfo )
+        void ApplyActionConventions( ControllerModel controller, Tuple<IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>> controllerVersionInfo )
         {
             Contract.Requires( controller != null );
 
@@ -111,7 +111,7 @@
             }
         }
 
-        void MergeActionAttributesWithConventions( ControllerModel controller, (IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>) controllerVersionInfo )
+        void MergeActionAttributesWithConventions( ControllerModel controller, Tuple<IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>> controllerVersionInfo )
         {
             Contract.Requires( controller != null );
 

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ControllerApiVersionConventionBuilderBase.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/Conventions/ControllerApiVersionConventionBuilderBase.cs
@@ -1,16 +1,11 @@
-﻿#pragma warning disable SA1200 // Using directives should be placed correctly; false positive - required for inner, short-hand type aliasing
-using System;
-using System.Collections.Generic;
-#pragma warning restore SA1200
-
-namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
+﻿namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
 {
     using Microsoft.AspNetCore.Mvc.ApplicationModels;
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics.Contracts;
     using System.Linq;
     using System.Reflection;
-    using ControllerVersionInfo = System.Tuple<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiVersion>>;
 
     /// <content>
     /// Provides additional implementation specific to Microsoft ASP.NET Core.
@@ -47,10 +42,9 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             }
         }
 
-        ControllerVersionInfo ApplyControllerConventions( ControllerModel controllerModel )
+        (IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>) ApplyControllerConventions( ControllerModel controllerModel )
         {
             Contract.Requires( controllerModel != null );
-            Contract.Ensures( Contract.Result<ControllerVersionInfo>() != null );
 
             MergeControllerAttributesWithConventions( controllerModel );
 
@@ -63,7 +57,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                 controllerModel.SetProperty( new ApiVersionModel( VersionNeutral, supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions ) );
             }
 
-            return new ControllerVersionInfo( supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions );
+            return (supportedVersions, deprecatedVersions, advertisedVersions, deprecatedAdvertisedVersions);
         }
 
         void MergeControllerAttributesWithConventions( ControllerModel controllerModel )
@@ -103,10 +97,9 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                                                     select version );
         }
 
-        void ApplyActionConventions( ControllerModel controller, ControllerVersionInfo controllerVersionInfo )
+        void ApplyActionConventions( ControllerModel controller, (IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>) controllerVersionInfo )
         {
             Contract.Requires( controller != null );
-            Contract.Requires( controllerVersionInfo != null );
 
             if ( VersionNeutral )
             {
@@ -118,10 +111,9 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             }
         }
 
-        void MergeActionAttributesWithConventions( ControllerModel controller, ControllerVersionInfo controllerVersionInfo )
+        void MergeActionAttributesWithConventions( ControllerModel controller, (IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>) controllerVersionInfo )
         {
             Contract.Requires( controller != null );
-            Contract.Requires( controllerVersionInfo != null );
 
             foreach ( var action in controller.Actions )
             {
@@ -133,7 +125,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                 {
                     action.SetProperty( controllerVersionInfo );
                     actionConvention.ApplyTo( action );
-                    action.SetProperty( default( ControllerVersionInfo ) );
+                    action.RemoveProperty( controllerVersionInfo );
                 }
                 else
                 {

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/Description/ODataApiExplorerTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/Description/ODataApiExplorerTest.cs
@@ -14,8 +14,6 @@
         public void api_descriptions_should_collate_expected_versions( HttpConfiguration configuration )
         {
             // arrange
-            var assembliesResolver = configuration.Services.GetAssembliesResolver();
-            var controllerTypes = configuration.Services.GetHttpControllerTypeResolver().GetControllerTypes( assembliesResolver );
             var apiExplorer = new ODataApiExplorer( configuration );
 
             // act
@@ -74,8 +72,6 @@
         public void api_descriptions_should_not_contain_metadata_controllers( HttpConfiguration configuration )
         {
             // arrange
-            var assembliesResolver = configuration.Services.GetAssembliesResolver();
-            var controllerTypes = configuration.Services.GetHttpControllerTypeResolver().GetControllerTypes( assembliesResolver );
             var apiExplorer = new ODataApiExplorer( configuration );
 
             // act

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/Description/TestConfigurations.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/Description/TestConfigurations.cs
@@ -2,7 +2,6 @@
 {
     using Microsoft.AspNet.OData.Builder;
     using Microsoft.Web.Http.Simulators.Configuration;
-    using Microsoft.Web.Http.Simulators.Models;
     using Microsoft.Web.Http.Versioning.Conventions;
     using System.Collections;
     using System.Collections.Generic;
@@ -34,7 +33,7 @@
                     options.Conventions.Controller<Simulators.V1.OrdersController>()
                                        .HasApiVersion( 1, 0 )
                                        .HasDeprecatedApiVersion( 0, 9 )
-                                       .Action( c => c.Post( default( Order ) ) ).MapToApiVersion( 1, 0 );
+                                       .Action( c => c.Post( default ) ).MapToApiVersion( 1, 0 );
                     options.Conventions.Controller<Simulators.V2.OrdersController>()
                                        .HasApiVersion( 2, 0 );
                     options.Conventions.Controller<Simulators.V3.OrdersController>()
@@ -59,14 +58,16 @@
                typeof( Simulators.V1.PeopleController ),
                typeof( Simulators.V2.PeopleController ),
                typeof( Simulators.V3.PeopleController ) );
+
+            configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), controllerTypeResolver );
+            configuration.AddApiVersioning();
+
             var builder = new VersionedODataModelBuilder( configuration )
             {
                 ModelConfigurations = { new PersonModelConfiguration() }
             };
             var models = builder.GetEdmModels();
 
-            configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), controllerTypeResolver );
-            configuration.AddApiVersioning();
             configuration.MapVersionedODataRoutes( "odata", "api/v{apiVersion}", models );
 
             return configuration;

--- a/test/Microsoft.AspNet.OData.Versioning.Tests/HttpConfigurationExtensionsTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.Tests/HttpConfigurationExtensionsTest.cs
@@ -120,6 +120,7 @@
 
             controllerTypeResolver.Setup( ctr => ctr.GetControllerTypes( It.IsAny<IAssembliesResolver>() ) ).Returns( controllerTypes );
             configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), controllerTypeResolver.Object );
+            configuration.AddApiVersioning();
 
             var builder = new VersionedODataModelBuilder( configuration );
 

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
@@ -95,7 +95,7 @@
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=" + version );
 
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( options => options.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -124,7 +124,7 @@
             var configuration = new HttpConfiguration();
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=" + version );
 
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( options => options.ReportApiVersions = true );
             configuration.Routes.MapHttpRoute( "Default", "api/{controller}/{id}", new { id = Optional } );
             configuration.EnsureInitialized();
 
@@ -633,10 +633,10 @@
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, "http://localhost/orders" );
 
-            configuration.AddApiVersioning( o =>
+            configuration.AddApiVersioning( options =>
                 {
-                    o.AssumeDefaultVersionWhenUnspecified = true;
-                    o.ApiVersionSelector = new LowestImplementedApiVersionSelector( o );
+                    options.AssumeDefaultVersionWhenUnspecified = true;
+                    options.ApiVersionSelector = new LowestImplementedApiVersionSelector( options );
                 } );
             configuration.Routes.MapHttpRoute( "Default", "{controller}/{id}", new { id = Optional } );
             configuration.EnsureInitialized();
@@ -655,7 +655,7 @@
                 RequestContext = new HttpRequestContext()
                 {
                     Configuration = configuration,
-                    RouteData = routeData
+                    RouteData = routeData,
                 }
             };
 
@@ -936,7 +936,7 @@ Microsoft.Web.Http.Dispatcher.ApiVersionControllerSelectorTest+AmbiguousNeutralC
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, requestUri );
 
-            configuration.AddApiVersioning();
+            configuration.AddApiVersioning( options => options.ReportApiVersions = true );
             configuration.EnsureInitialized();
 
             var routeData = configuration.Routes.GetRouteData( request );
@@ -1142,15 +1142,16 @@ Microsoft.Web.Http.Dispatcher.ApiVersionControllerSelectorTest+AmbiguousNeutralC
 
             controllerTypeResolver.Setup( r => r.GetControllerTypes( It.IsAny<IAssembliesResolver>() ) ).Returns( controllerTypes );
             configuration.Services.Replace( typeof( IHttpControllerTypeResolver ), controllerTypeResolver.Object );
-            configuration.AddApiVersioning( o =>
+            configuration.AddApiVersioning( options =>
             {
-                o.Conventions.Controller<ConventionsController>()
-                             .HasApiVersion( 1, 0 )
-                             .HasApiVersion( 2, 0 )
-                             .Action( c => c.GetV2() ).MapToApiVersion( 2, 0 )
-                             .Action( c => c.GetV2( default ) ).MapToApiVersion( 2, 0 );
+                options.ReportApiVersions = true;
+                options.Conventions.Controller<ConventionsController>()
+                                   .HasApiVersion( 1, 0 )
+                                   .HasApiVersion( 2, 0 )
+                                   .Action( c => c.GetV2() ).MapToApiVersion( 2, 0 )
+                                   .Action( c => c.GetV2( default ) ).MapToApiVersion( 2, 0 );
 
-                o.Conventions.Controller<Conventions2Controller>().HasApiVersion( 3, 0 );
+                options.Conventions.Controller<Conventions2Controller>().HasApiVersion( 3, 0 );
             } );
             configuration.Routes.MapHttpRoute( "Default", "api/{controller}/{id}", new { id = Optional } );
             configuration.MapHttpAttributeRoutes();

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Microsoft.AspNet.WebApi.Versioning.Tests.csproj
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Microsoft.AspNet.WebApi.Versioning.Tests.csproj
@@ -13,6 +13,7 @@
  <ItemGroup>
   <Reference Include="Microsoft.CSharp" />
   <Reference Include="System" />
+  <Reference Include="System.Web" />
  </ItemGroup>
  
  <ItemGroup>

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpActionDescriptorExtensionsTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpActionDescriptorExtensionsTest.cs
@@ -39,7 +39,7 @@
         }
 
         [Fact]
-        public void get_api_version_info_should_add_and_return_new_instance_for_action_descriptor()
+        public void get_api_version_info_should_return_new_instance_for_action_descriptor()
         {
             // arrange
             var controller = new Mock<IHttpController>().Object;
@@ -53,11 +53,11 @@
 
             // assert
             versionInfo.Should().NotBeNull();
-            actionDescriptor.Properties.ContainsKey( "MS_ApiVersionInfo" ).Should().BeTrue();
+            actionDescriptor.Properties.ContainsKey( typeof( ApiVersionModel ) ).Should().BeFalse();
         }
 
         [Fact]
-        public void get_api_version_info_should_returne_exising_instance_for_action_descriptor()
+        public void get_api_version_info_should_return_exising_instance_for_action_descriptor()
         {
             // arrange
             var controller = new Mock<IHttpController>().Object;
@@ -65,7 +65,7 @@
             var actionDescriptor = new Mock<HttpActionDescriptor>( controllerDescriptor ) { CallBase = true }.Object;
             var assignedVersionInfo = ApiVersionModel.Default;
 
-            actionDescriptor.Properties["MS_ApiVersionInfo"] = assignedVersionInfo;
+            actionDescriptor.Properties[typeof(ApiVersionModel)] = assignedVersionInfo;
 
             // act
             var versionInfo = actionDescriptor.GetApiVersionModel();

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpControllerDescriptorExtensionsTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpControllerDescriptorExtensionsTest.cs
@@ -11,72 +11,6 @@
 
     public class HttpControllerDescriptorExtensionsTest
     {
-        public static IEnumerable<object[]> DeclaredApiVersionData
-        {
-            get
-            {
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestController ) ),
-                    new[] { ApiVersion.Default }
-                };
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestVersion2Controller ) ),
-                    new[] { new ApiVersion( 1, 8 ), new ApiVersion( 1, 9 ), new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) }
-                };
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( AttributeRoutedTest4Controller ) ),
-                    new[] { new ApiVersion( 4, 0 ) }
-                };
-            }
-        }
-
-        public static IEnumerable<object[]> SupportedApiVersionData
-        {
-            get
-            {
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestController ) ),
-                    new[] { ApiVersion.Default }
-                };
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestVersion2Controller ) ),
-                    new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) }
-                };
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( AttributeRoutedTest4Controller ) ),
-                    new[] { new ApiVersion( 1, 0 ), new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ), new ApiVersion( 4, 0 ) }
-                };
-            }
-        }
-
-        public static IEnumerable<object[]> DeprecatedApiVersionData
-        {
-            get
-            {
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestController ) ),
-                    new ApiVersion[0]
-                };
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestVersion2Controller ) ),
-                    new[] { new ApiVersion( 1, 8 ), new ApiVersion( 1, 9 ) }
-                };
-                yield return new object[]
-                {
-                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( AttributeRoutedTest4Controller ) ),
-                    new[] { new ApiVersion( 3, 0, "Alpha" ) }
-                };
-            }
-        }
-
         [Fact]
         public void get_api_version_info_should_add_and_return_new_instance_for_controller_descriptor()
         {
@@ -94,14 +28,14 @@
         }
 
         [Fact]
-        public void get_api_version_info_should_returne_exising_instance_for_controller_descriptor()
+        public void get_api_version_info_should_return_exising_instance_for_controller_descriptor()
         {
             // arrange
             var controller = new Mock<IHttpController>().Object;
             var controllerDescriptor = new HttpControllerDescriptor( new HttpConfiguration(), "Tests", controller.GetType() );
             var assignedVersionInfo = ApiVersionModel.Default;
 
-            controllerDescriptor.Properties["MS_ApiVersionInfo"] = assignedVersionInfo;
+            controllerDescriptor.Properties[typeof(ApiVersionModel)] = assignedVersionInfo;
 
             // act
             var versionInfo = controllerDescriptor.GetApiVersionModel();
@@ -211,6 +145,72 @@
 
             // assert
             deprecatedVersions.Should().BeEquivalentTo( expectedVersions );
+        }
+
+        public static IEnumerable<object[]> DeclaredApiVersionData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestController ) ),
+                    new[] { ApiVersion.Default }
+                };
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestVersion2Controller ) ),
+                    new[] { new ApiVersion( 1, 8 ), new ApiVersion( 1, 9 ), new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) }
+                };
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( AttributeRoutedTest4Controller ) ),
+                    new[] { new ApiVersion( 4, 0 ) }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> SupportedApiVersionData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestController ) ),
+                    new[] { ApiVersion.Default }
+                };
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestVersion2Controller ) ),
+                    new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) }
+                };
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( AttributeRoutedTest4Controller ) ),
+                    new[] { new ApiVersion( 1, 0 ), new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ), new ApiVersion( 4, 0 ) }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> DeprecatedApiVersionData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestController ) ),
+                    new ApiVersion[0]
+                };
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( TestVersion2Controller ) ),
+                    new[] { new ApiVersion( 1, 8 ), new ApiVersion( 1, 9 ) }
+                };
+                yield return new object[]
+                {
+                    new HttpControllerDescriptor( new HttpConfiguration(), "Tests", typeof( AttributeRoutedTest4Controller ) ),
+                    new[] { new ApiVersion( 3, 0, "Alpha" ) }
+                };
+            }
         }
     }
 }

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpRouteCollectionExtensionsTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/System.Web.Http/HttpRouteCollectionExtensionsTest.cs
@@ -1,0 +1,142 @@
+﻿namespace System.Web.Http
+{
+    using FluentAssertions;
+    using Moq;
+    using System.Collections.Generic;
+    using System.Web.Http.Routing;
+    using System.Web.Http.WebHost.Routing;
+    using Xunit;
+
+    public class HttpRouteCollectionExtensionsTest
+    {
+        [Fact]
+        public void to_dictionary_should_convert_route_collection()
+        {
+            // arrange
+            var route = Mock.Of<IHttpRoute>();
+            var routes = new HttpRouteCollection()
+            {
+                { "test", route },
+            };
+
+            // act
+            var dictionary = routes.ToDictionary();
+
+            // assert
+            dictionary.Should().BeEquivalentTo( new Dictionary<string, IHttpRoute>() { ["test"] = route } );
+        }
+
+        [Fact]
+        public void to_dictionary_should_convert_route_collection_when_hosted_with_SystemX2EWeb()
+        {
+            // arrange
+            var route = Mock.Of<IHttpRoute>();
+            var routes = new HostedHttpRouteCollection()
+            {
+                { "test", route },
+            };
+
+            // act
+            var dictionary = routes.ToDictionary();
+
+            // assert
+            dictionary.Should().BeEquivalentTo( new Dictionary<string, IHttpRoute>() { ["test"] = route } );
+        }
+    }
+}
+
+// note: HostedHttpRouteCollection is an internal type. in order to test the expected behavior of the
+// HttpRouteCollectionExtensions.ToDictionary hack, the bare minimum implementation is duplicated here
+namespace System.Web.Http.WebHost.Routing
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Web.Http.Routing;
+    using System.Web.Routing;
+
+    internal sealed class HostedHttpRouteCollection : HttpRouteCollection
+    {
+        private readonly RouteCollection _routeCollection = new RouteCollection();
+
+        public override string VirtualPathRoot => throw NotUsedInUnitTest();
+
+        public override int Count => _routeCollection.Count;
+
+        public override IHttpRoute this[string name] => ( (HttpWebRoute) _routeCollection[name] ).HttpRoute;
+
+        public override IHttpRoute this[int index] => ( (HttpWebRoute) _routeCollection[index] ).HttpRoute;
+
+        public override IHttpRouteData GetRouteData( HttpRequestMessage request ) => throw NotUsedInUnitTest();
+
+        public override IHttpVirtualPathData GetVirtualPath( HttpRequestMessage request, string name, IDictionary<string, object> values ) => throw NotUsedInUnitTest();
+
+        public override IHttpRoute CreateRoute( string uriTemplate, IDictionary<string, object> defaults, IDictionary<string, object> constraints, IDictionary<string, object> dataTokens, HttpMessageHandler handler ) => throw NotUsedInUnitTest();
+
+        public override void Add( string name, IHttpRoute route ) => _routeCollection.Add( name, new HttpWebRoute( route ) );
+
+        public override void Clear() => _routeCollection.Clear();
+
+        public override bool Contains( IHttpRoute item )
+        {
+            foreach ( var route in _routeCollection )
+            {
+                if ( route is HttpWebRoute webRoute && webRoute.HttpRoute == item )
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public override bool ContainsKey( string name ) => _routeCollection[name] != null;
+
+        public override void CopyTo( IHttpRoute[] array, int arrayIndex ) => throw NotSupportedByHostedRouteCollection();
+
+        public override void CopyTo( KeyValuePair<string, IHttpRoute>[] array, int arrayIndex ) => throw NotSupportedByRouteCollection();
+
+        public override void Insert( int index, string name, IHttpRoute value ) => throw NotSupportedByRouteCollection();
+
+        public override bool Remove( string name ) => throw NotSupportedByRouteCollection();
+
+        public override IEnumerator<IHttpRoute> GetEnumerator() => _routeCollection.OfType<HttpWebRoute>().Select( r => r.HttpRoute ).GetEnumerator();
+
+        public override bool TryGetValue( string name, out IHttpRoute route )
+        {
+            if ( _routeCollection[name] is HttpWebRoute rt )
+            {
+                route = rt.HttpRoute;
+                return true;
+            }
+
+            route = null;
+            return false;
+        }
+
+        static NotSupportedException NotSupportedByRouteCollection() => new NotSupportedException();
+
+        static NotSupportedException NotSupportedByHostedRouteCollection() => new NotSupportedException();
+
+        static NotImplementedException NotUsedInUnitTest() => new NotImplementedException( "Not used in unit tests" );
+    }
+}
+
+namespace System.Web.Http.WebHost.Routing
+{
+    using Moq;
+    using System.Web.Http.Routing;
+    using System.Web.Routing;
+
+    internal sealed class HttpWebRoute : Route
+    {
+        public HttpWebRoute( IHttpRoute httpRoute )
+            : base( httpRoute.RouteTemplate,
+                   new RouteValueDictionary(),
+                   new RouteValueDictionary(),
+                   new RouteValueDictionary(),
+                   Mock.Of<IRouteHandler>() ) => HttpRoute = httpRoute;
+
+        public IHttpRoute HttpRoute { get; }
+    }
+}

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTTest.cs
@@ -2,7 +2,9 @@
 {
     using FluentAssertions;
     using Moq;
+    using System;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Reflection;
     using System.Web.Http;
     using System.Web.Http.Controllers;
@@ -18,8 +20,11 @@
             var controllerBuilder = new ControllerApiVersionConventionBuilder<UndecoratedController>();
             var actionBuilder = new ActionApiVersionConventionBuilder<UndecoratedController>( controllerBuilder );
             var actionDescriptor = new Mock<HttpActionDescriptor>() { CallBase = true };
+            var empty = Enumerable.Empty<ApiVersion>();
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionDescriptor.Setup( ad => ad.GetCustomAttributes<IApiVersionProvider>() ).Returns( new Collection<IApiVersionProvider>() );
+            actionDescriptor.Object.Properties[controllerVersionInfo.GetType()] = controllerVersionInfo;
 
             // act
             actionBuilder.ApplyTo( actionDescriptor.Object );
@@ -32,7 +37,7 @@
                     DeclaredApiVersions = new ApiVersion[0],
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -43,8 +48,11 @@
             var controllerBuilder = new ControllerApiVersionConventionBuilder<UndecoratedController>();
             var actionBuilder = new ActionApiVersionConventionBuilder<UndecoratedController>( controllerBuilder );
             var actionDescriptor = new Mock<HttpActionDescriptor>() { CallBase = true };
+            var empty = Enumerable.Empty<ApiVersion>();
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionDescriptor.Setup( ad => ad.GetCustomAttributes<IApiVersionProvider>() ).Returns( new Collection<IApiVersionProvider>() );
+            actionDescriptor.Object.Properties[controllerVersionInfo.GetType()] = controllerVersionInfo;
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) );
 
             // act
@@ -56,9 +64,9 @@
                 {
                     IsApiVersionNeutral = false,
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ) },
-                    SupportedApiVersions = new[] { new ApiVersion( 2, 0 ) },
+                    SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new[] { new ApiVersion( 2, 0 ) }
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -71,7 +79,10 @@
             var controllerDescriptor = new HttpControllerDescriptor() { ControllerType = typeof( DecoratedController ) };
             var method = typeof( DecoratedController ).GetMethod( nameof( DecoratedController.Get ) );
             var actionDescriptor = new ReflectedHttpActionDescriptor( controllerDescriptor, method );
+            var empty = Enumerable.Empty<ApiVersion>();
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
+            actionDescriptor.Properties[controllerVersionInfo.GetType()] = controllerVersionInfo;
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )
                          .MapToApiVersion( new ApiVersion( 3, 0 ) );
 
@@ -84,9 +95,9 @@
                 {
                     IsApiVersionNeutral = false,
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) },
-                    SupportedApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) },
+                    SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) }
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -2,7 +2,9 @@
 {
     using FluentAssertions;
     using Moq;
+    using System;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Reflection;
     using System.Web.Http;
     using System.Web.Http.Controllers;
@@ -18,8 +20,11 @@
             var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
             var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
             var actionDescriptor = new Mock<HttpActionDescriptor>() { CallBase = true };
+            var empty = Enumerable.Empty<ApiVersion>();
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionDescriptor.Setup( ad => ad.GetCustomAttributes<IApiVersionProvider>() ).Returns( new Collection<IApiVersionProvider>() );
+            actionDescriptor.Object.Properties[controllerVersionInfo.GetType()] = controllerVersionInfo;
 
             // act
             actionBuilder.ApplyTo( actionDescriptor.Object );
@@ -32,7 +37,7 @@
                     DeclaredApiVersions = new ApiVersion[0],
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -43,8 +48,11 @@
             var controllerBuilder = new ControllerApiVersionConventionBuilder( typeof( UndecoratedController ) );
             var actionBuilder = new ActionApiVersionConventionBuilder( controllerBuilder );
             var actionDescriptor = new Mock<HttpActionDescriptor>() { CallBase = true };
+            var empty = Enumerable.Empty<ApiVersion>();
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionDescriptor.Setup( ad => ad.GetCustomAttributes<IApiVersionProvider>() ).Returns( new Collection<IApiVersionProvider>() );
+            actionDescriptor.Object.Properties[controllerVersionInfo.GetType()] = controllerVersionInfo;
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) );
 
             // act
@@ -56,9 +64,9 @@
                 {
                     IsApiVersionNeutral = false,
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ) },
-                    SupportedApiVersions = new[] { new ApiVersion( 2, 0 ) },
+                    SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new[] { new ApiVersion( 2, 0 ) }
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -71,7 +79,10 @@
             var controllerDescriptor = new HttpControllerDescriptor() { ControllerType = typeof( DecoratedController ) };
             var method = typeof( DecoratedController ).GetMethod( nameof( DecoratedController.Get ) );
             var actionDescriptor = new ReflectedHttpActionDescriptor( controllerDescriptor, method );
+            var empty = Enumerable.Empty<ApiVersion>();
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
+            actionDescriptor.Properties[controllerVersionInfo.GetType()] = controllerVersionInfo;
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )
                          .MapToApiVersion( new ApiVersion( 3, 0 ) );
 
@@ -84,9 +95,9 @@
                 {
                     IsApiVersionNeutral = false,
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) },
-                    SupportedApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) },
+                    SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) }
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTTest.cs
@@ -3,6 +3,7 @@
     using ApplicationModels;
     using FluentAssertions;
     using Moq;
+    using System;
     using System.Linq;
     using System.Reflection;
     using Xunit;
@@ -19,7 +20,7 @@
             var method = typeof( UndecoratedController ).GetMethod( nameof( UndecoratedController.Get ) );
             var actionModel = new ActionModel( method, new object[0] );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = (empty, empty, empty, empty);
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionModel.SetProperty( controllerVersionInfo );
 
@@ -48,7 +49,7 @@
             var attributes = new object[] { new MapToApiVersionAttribute( "2.0" ) };
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = (empty, empty, empty, empty);
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) );
@@ -78,7 +79,7 @@
             var attributes = method.GetCustomAttributes().Cast<object>().ToArray();
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = (empty, empty, empty, empty);
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
+﻿namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
 {
     using ApplicationModels;
     using FluentAssertions;
@@ -10,7 +7,6 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
     using System.Reflection;
     using Xunit;
     using static Moq.Times;
-    using ControllerVersionInfo = Tuple<IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>>;
 
     public class ActionApiVersionConventionBuilderTTest
     {
@@ -23,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             var method = typeof( UndecoratedController ).GetMethod( nameof( UndecoratedController.Get ) );
             var actionModel = new ActionModel( method, new object[0] );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = new ControllerVersionInfo( empty, empty, empty, empty );
+            var controllerVersionInfo = (empty, empty, empty, empty);
 
             actionModel.SetProperty( controllerVersionInfo );
 
@@ -38,7 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                     DeclaredApiVersions = new ApiVersion[0],
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -52,7 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             var attributes = new object[] { new MapToApiVersionAttribute( "2.0" ) };
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = new ControllerVersionInfo( empty, empty, empty, empty );
+            var controllerVersionInfo = (empty, empty, empty, empty);
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) );
@@ -68,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ) },
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -82,7 +78,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             var attributes = method.GetCustomAttributes().Cast<object>().ToArray();
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = new ControllerVersionInfo( empty, empty, empty, empty );
+            var controllerVersionInfo = (empty, empty, empty, empty);
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )
@@ -99,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) },
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -3,6 +3,7 @@
     using ApplicationModels;
     using FluentAssertions;
     using Moq;
+    using System;
     using System.Linq;
     using System.Reflection;
     using Xunit;
@@ -19,7 +20,7 @@
             var method = typeof( UndecoratedController ).GetMethod( nameof( UndecoratedController.Get ) );
             var actionModel = new ActionModel( method, new object[0] );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = (empty, empty, empty, empty);
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionModel.SetProperty( controllerVersionInfo );
 
@@ -48,7 +49,7 @@
             var attributes = new object[] { new MapToApiVersionAttribute( "2.0" ) };
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = (empty, empty, empty, empty);
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) );
@@ -78,7 +79,7 @@
             var attributes = method.GetCustomAttributes().Cast<object>().ToArray();
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = (empty, empty, empty, empty);
+            var controllerVersionInfo = Tuple.Create( empty, empty, empty, empty );
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/ActionApiVersionConventionBuilderTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
+﻿namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
 {
     using ApplicationModels;
     using FluentAssertions;
@@ -10,7 +7,6 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
     using System.Reflection;
     using Xunit;
     using static Moq.Times;
-    using ControllerVersionInfo = Tuple<IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>, IEnumerable<ApiVersion>>;
 
     public class ActionApiVersionConventionBuilderTest
     {
@@ -23,7 +19,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             var method = typeof( UndecoratedController ).GetMethod( nameof( UndecoratedController.Get ) );
             var actionModel = new ActionModel( method, new object[0] );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = new ControllerVersionInfo( empty, empty, empty, empty );
+            var controllerVersionInfo = (empty, empty, empty, empty);
 
             actionModel.SetProperty( controllerVersionInfo );
 
@@ -38,7 +34,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                     DeclaredApiVersions = new ApiVersion[0],
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -52,7 +48,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             var attributes = new object[] { new MapToApiVersionAttribute( "2.0" ) };
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = new ControllerVersionInfo( empty, empty, empty, empty );
+            var controllerVersionInfo = (empty, empty, empty, empty);
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) );
@@ -68,7 +64,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ) },
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 
@@ -82,7 +78,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
             var attributes = method.GetCustomAttributes().Cast<object>().ToArray();
             var actionModel = new ActionModel( method, attributes );
             var empty = Enumerable.Empty<ApiVersion>();
-            var controllerVersionInfo = new ControllerVersionInfo( empty, empty, empty, empty );
+            var controllerVersionInfo = (empty, empty, empty, empty);
 
             actionModel.SetProperty( controllerVersionInfo );
             actionBuilder.MapToApiVersion( new ApiVersion( 2, 0 ) )
@@ -99,7 +95,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
                     DeclaredApiVersions = new[] { new ApiVersion( 2, 0 ), new ApiVersion( 3, 0 ) },
                     SupportedApiVersions = new ApiVersion[0],
                     DeprecatedApiVersions = new ApiVersion[0],
-                    ImplementedApiVersions = new ApiVersion[0]
+                    ImplementedApiVersions = new ApiVersion[0],
                 } );
         }
 


### PR DESCRIPTION
This PR completely refactors the internal discovery, application, and aggregation of API version models in Web API. Models are now pre-aggregated upfront just as they are in ASP.NET Core. This results in better post-startup performance and removes potential issues from changing models or their associated property bags at runtime.

Along the way, the refactoring fixes the issue caused in #322. This change will also set the initial ground work for splitting implementations across types and action-versioned APIs.
