### PR TITLE
Version parsing from namespace bug fix

### DIFF
--- a/src/Common/Versioning/Conventions/VersionByNamespaceConvention.cs
+++ b/src/Common/Versioning/Conventions/VersionByNamespaceConvention.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning.Conventions
 
             // 'v' | 'V' : [<year> '-' <month> '-' <day>] : [<major[.minor]>] : [<status>]
             // ex: v2018_04_01_1_1_Beta
-            const string Pattern = @"(?:^|\.)[vV](\d{4})?_?(\d{2})?_?(\d{2})?_?(\d+)?_?(\d*)_?([a-zA-Z][a-zA-Z0-9]*)?(?:$|\.)";
+            const string Pattern = @"(?:^|\.)[vV](\d{4})?_?(\d{2})?_?(\d{2})?_?(\d+)?_?(\d*)_?([a-zA-Z][a-zA-Z0-9]*)?(?=($|\.))";
 
             var match = Regex.Match( @namespace, Pattern, Singleline );
             var rawApiVersions = new List<string>();

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/VersionByNamespaceConventionTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/Conventions/VersionByNamespaceConventionTest.cs
@@ -23,6 +23,7 @@
         [InlineData( "Contoso.Api.v2018_04_01_Beta.Controllers", "2018-04-01-Beta" )]
         [InlineData( "Contoso.Api.v2018_04_01_1_0_Beta.Controllers", "2018-04-01.1.0-Beta" )]
         [InlineData( "MyRestaurant.Vegetarian.Food.v1_1.Controllers", "1.1" )]
+        [InlineData( "VersioningSample.V5.Controllers", "5.0" )]
         public void apply_should_infer_supported_api_version_from_namespace( string @namespace, string versionText )
         {
             // arrange
@@ -56,6 +57,7 @@
         [InlineData( "Contoso.Api.v2018_04_01_Beta.Controllers", "2018-04-01-Beta" )]
         [InlineData( "Contoso.Api.v2018_04_01_1_0_Beta.Controllers", "2018-04-01.1.0-Beta" )]
         [InlineData( "MyRestaurant.Vegetarian.Food.v1_1.Controllers", "1.1" )]
+        [InlineData( "VersioningSample.V5.Controllers", "5.0" )]
         public void apply_should_infer_deprecated_api_version_from_namespace( string @namespace, string versionText )
         {
             // arrange


### PR DESCRIPTION
When some controller namespace contains segment starting with `v`, and the next segment contains actual version, then `VersionByNamespaceConvention` skips second segment due to dividing dot capture.

For example version parsing fails with namespace `VersioningSample.V1.Controllers`.

This fix uses regex lookahead on trailing dot.