### PR TITLE
avoid reflecting the query string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ artifacts/
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
+_NCrunch_ApiVersioning/

--- a/ApiVersioning.v3.ncrunchsolution
+++ b/ApiVersioning.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>False</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/Common/Common.projitems
+++ b/src/Common/Common.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MapToApiVersionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReportApiVersionsAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UriExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\AmbiguousApiVersionException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\ApiVersionFormatProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\ApiVersioningOptions.cs" />

--- a/src/Common/UriExtensions.cs
+++ b/src/Common/UriExtensions.cs
@@ -5,14 +5,9 @@ namespace Microsoft.AspNetCore.Mvc
 #endif
 {
     using System;
-    using static System.String;
 
     static class UriExtensions
     {
-        internal static string SafeFullPath(this Uri uri)
-        {
-            var safeUrl = IsNullOrWhiteSpace( uri.Query ) ? uri.AbsoluteUri : uri.AbsoluteUri.Replace( uri.Query, Empty );
-            return safeUrl;
-        }
+        internal static string SafeFullPath( this Uri uri ) => uri.GetLeftPart( UriPartial.Path );
     }
 }

--- a/src/Common/UriExtensions.cs
+++ b/src/Common/UriExtensions.cs
@@ -1,0 +1,18 @@
+﻿#if WEBAPI
+namespace Microsoft.Web.Http
+#else
+namespace Microsoft.AspNetCore.Mvc
+#endif
+{
+    using System;
+    using static System.String;
+
+    static class UriExtensions
+    {
+        internal static string SafeFullPath(this Uri uri)
+        {
+            var safeUrl = IsNullOrWhiteSpace( uri.Query ) ? uri.AbsoluteUri : uri.AbsoluteUri.Replace( uri.Query, Empty );
+            return safeUrl;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpResponseExceptionFactory.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Dispatcher/HttpResponseExceptionFactory.cs
@@ -129,8 +129,10 @@
             Contract.Requires( requestedVersion != null );
             Contract.Ensures( Contract.Result<HttpResponseMessage>() != null );
 
-            var message = SR.VersionedResourceNotSupported.FormatDefault( request.RequestUri, requestedVersion );
-            var messageDetail = SR.VersionedControllerNameNotFound.FormatDefault( request.RequestUri, requestedVersion );
+            var safeUrl = request.RequestUri.SafeFullPath();
+
+            var message = SR.VersionedResourceNotSupported.FormatDefault( safeUrl, requestedVersion );
+            var messageDetail = SR.VersionedControllerNameNotFound.FormatDefault( safeUrl, requestedVersion );
 
             TraceWriter.Info( request, ControllerSelectorCategory, message );
 
@@ -153,7 +155,9 @@
             var requestedMethod = request.Method;
             var version = request.GetRequestedApiVersion()?.ToString() ?? "(null)";
             var message = SR.VersionedMethodNotSupported.FormatDefault( version, requestedMethod );
-            var messageDetail = SR.VersionedActionNameNotFound.FormatDefault( request.RequestUri, requestedMethod, version );
+            var safeUrl = request.RequestUri.SafeFullPath();
+
+            var messageDetail = SR.VersionedActionNameNotFound.FormatDefault( safeUrl, requestedMethod, version );
 
             TraceWriter.Info( request, ControllerSelectorCategory, message );
             response = Options.ErrorResponses.MethodNotAllowed( request, UnsupportedApiVersion, message, messageDetail );
@@ -185,12 +189,14 @@
         {
             Contract.Requires( conventionRouteResult != null );
 
-            var message = SR.ResourceNotFound.FormatDefault( request.RequestUri );
+            var safeUrl = request.RequestUri.SafeFullPath();
+
+            var message = SR.ResourceNotFound.FormatDefault( safeUrl );
             var messageDetail = default( string );
 
             if ( IsNullOrEmpty( conventionRouteResult.ControllerName ) )
             {
-                messageDetail = SR.ControllerNameNotFound.FormatDefault( request.RequestUri );
+                messageDetail = SR.ControllerNameNotFound.FormatDefault( safeUrl );
             }
             else
             {

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Routing/DefaultApiVersionRoutePolicy.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Routing/DefaultApiVersionRoutePolicy.cs
@@ -212,6 +212,8 @@
             var allowedMethods = new Lazy<HashSet<string>>( () => AllowedMethodsFromCandidates( candidates, parsedVersion ) );
             var apiVersions = new Lazy<ApiVersionModel>( candidates.Select( a => a.GetProperty<ApiVersionModel>() ).Aggregate );
             var handlerContext = new RequestHandlerContext( ErrorResponseProvider, ApiVersionReporter, apiVersions );
+            var url = new Uri( requestUrl.Value );
+            var safeUrl = url.SafeFullPath();
 
             if ( parsedVersion == null )
             {
@@ -219,26 +221,26 @@
                 {
                     if ( Options.AssumeDefaultVersionWhenUnspecified || candidates.Any( c => c.IsApiVersionNeutral() ) )
                     {
-                        return VersionNeutralUnmatched( handlerContext, requestUrl.Value, method, allowedMethods.Value, actionNames.Value );
+                        return VersionNeutralUnmatched( handlerContext, safeUrl, method, allowedMethods.Value, actionNames.Value );
                     }
 
                     return UnspecifiedApiVersion( handlerContext, actionNames.Value );
                 }
                 else if ( !TryParse( requestedVersion, out parsedVersion ) )
                 {
-                    return MalformedApiVersion( handlerContext, requestUrl.Value, requestedVersion );
+                    return MalformedApiVersion( handlerContext, safeUrl, requestedVersion );
                 }
             }
             else if ( IsNullOrEmpty( requestedVersion ) )
             {
-                return VersionNeutralUnmatched( handlerContext, requestUrl.Value, method, allowedMethods.Value, actionNames.Value );
+                return VersionNeutralUnmatched( handlerContext, safeUrl, method, allowedMethods.Value, actionNames.Value );
             }
             else
             {
                 requestedVersion = parsedVersion.ToString();
             }
 
-            return Unmatched( handlerContext, requestUrl.Value, method, allowedMethods.Value, actionNames.Value, parsedVersion, requestedVersion );
+            return Unmatched( handlerContext, safeUrl, method, allowedMethods.Value, actionNames.Value, parsedVersion, requestedVersion );
         }
 
         static HashSet<string> AllowedMethodsFromCandidates( IEnumerable<ActionDescriptor> candidates, ApiVersion apiVersion )

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
@@ -57,7 +57,8 @@
         [Theory]
         [InlineData( "?additionalQuery=true" )]
         [InlineData( "?additionalQuery=true#anchor-123" )]
-        public async Task then_the_service_document_should_return_only_path_for_an_unsupported_version(string additionalUriPart )
+        [InlineData( "#anchor-123" )]
+        public async Task then_the_service_document_should_return_only_path_for_an_unsupported_version( string additionalUriPart )
         {
             // arrange
             var requestUrl = $"v4{additionalUriPart}";

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
@@ -54,11 +54,13 @@
             content.Error.Code.Should().Be( "UnsupportedApiVersion" );
         }
 
-        [Fact]
-        public async Task then_the_service_document_should_return_only_path_for_an_unsupported_version()
+        [Theory]
+        [InlineData( "?additionalQuery=true" )]
+        [InlineData( "?additionalQuery=true#anchor-123" )]
+        public async Task then_the_service_document_should_return_only_path_for_an_unsupported_version(string additionalUriPart )
         {
             // arrange
-            var requestUrl = "v4?additionalQuery=true";
+            var requestUrl = $"v4{additionalUriPart}";
 
             // act
             var response = await Client.GetAsync( requestUrl );
@@ -69,7 +71,7 @@
             response.StatusCode.Should().Be( BadRequest );
             content.Error.Code.Should().Be( "UnsupportedApiVersion" );
             content.Error.Message.Should().Contain( "v4" );
-            content.Error.Message.Should().NotContain( "?additionalQuery=true" );
+            content.Error.Message.Should().NotContain( additionalUriPart );
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
@@ -43,7 +43,7 @@
         public async Task then_service_document_should_return_400_for_unsupported_url_api_version()
         {
             // arrange
-            var requestUrl = $"v4";
+            var requestUrl = "v4";
 
             // act
             var response = await Client.GetAsync( requestUrl );
@@ -52,6 +52,24 @@
             // assert
             response.StatusCode.Should().Be( BadRequest );
             content.Error.Code.Should().Be( "UnsupportedApiVersion" );
+        }
+
+        [Fact]
+        public async Task then_the_service_document_should_return_only_path_for_an_unsupported_version()
+        {
+            // arrange
+            var requestUrl = "v4?additionalQuery=true";
+
+            // act
+            var response = await Client.GetAsync( requestUrl );
+            var content = await response.Content.ReadAsAsync<OneApiErrorResponse>();
+
+
+            // assert
+            response.StatusCode.Should().Be( BadRequest );
+            content.Error.Code.Should().Be( "UnsupportedApiVersion" );
+            content.Error.Message.Should().Contain( "v4" );
+            content.Error.Message.Should().NotContain( "?additionalQuery=true" );
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.Tests/Dispatcher/ApiVersionControllerSelectorTest.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Web.Http.Dispatcher
+﻿using FluentAssertions.Common;
+
+namespace Microsoft.Web.Http.Dispatcher
 {
     using Controllers;
     using FluentAssertions;
@@ -202,8 +204,8 @@
         public async Task select_controller_should_return_400_for_unmatchedX2C_attributeX2Dbased_controller_version()
         {
             // arrange
-            var message = "The HTTP resource that matches the request URI 'http://localhost/api/test?api-version=42.0' does not support the API version '42.0'.";
-            var messageDetail = "No route providing a controller name with API version '42.0' was found to match request URI 'http://localhost/api/test?api-version=42.0'.";
+            var message = "The HTTP resource that matches the request URI 'http://localhost/api/test' does not support the API version '42.0'.";
+            var messageDetail = "No route providing a controller name with API version '42.0' was found to match request URI 'http://localhost/api/test'.";
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=42.0" );
 
@@ -286,8 +288,8 @@
         public async Task select_controller_should_return_400_for_unmatchedX2C_conventionX2Dbased_controller_version()
         {
             // arrange
-            var message = "The HTTP resource that matches the request URI 'http://localhost/api/test?api-version=4.0' does not support the API version '4.0'.";
-            var messageDetail = "No route providing a controller name with API version '4.0' was found to match request URI 'http://localhost/api/test?api-version=4.0'.";
+            var message = "The HTTP resource that matches the request URI 'http://localhost/api/test' does not support the API version '4.0'.";
+            var messageDetail = "No route providing a controller name with API version '4.0' was found to match request URI 'http://localhost/api/test'.";
             var configuration = new HttpConfiguration();
             var request = new HttpRequestMessage( Get, "http://localhost/api/test?api-version=4.0" );
 
@@ -373,8 +375,10 @@
         [InlineData( "http://localhost/api/random?api-version=10.0" )]
         public async Task select_controller_should_return_404_for_unmatched_controller( string requestUri )
         {
+            var uri = new Uri( requestUri );
+            var safeUrl = string.IsNullOrWhiteSpace( uri.Query ) ? uri.AbsoluteUri : uri.AbsoluteUri.Replace( uri.Query, string.Empty );
             // arrange
-            var message = "No HTTP resource was found that matches the request URI '" + requestUri + "'.";
+            var message = "No HTTP resource was found that matches the request URI '" + safeUrl + "'.";
             var messageDetail = "No type was found that matches the controller named 'random'.";
             var configuration = AttributeRoutingEnabledConfiguration;
             var request = new HttpRequestMessage( Get, requestUri );

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Mvc/Basic/given a version-neutral Controller/when no version is specified.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Mvc/Basic/given a version-neutral Controller/when no version is specified.cs
@@ -44,5 +44,28 @@
                     Message = "The HTTP resource that matches the request URI 'http://localhost/api/ping' does not support HTTP method 'POST'."
                 } );
         }
+
+        [Fact]
+        public async Task then_unsupported_api_version_error_should_only_contain_the_path()
+        {
+            // arrange
+            var entity = new { };
+
+            // act
+            var response = await PostAsync( "api/ping?additionalQuery=true", entity );
+            var content = await response.Content.ReadAsAsync<OneApiErrorResponse>();
+
+            // assert
+            response.StatusCode.Should().Be( MethodNotAllowed );
+            response.Content.Headers.Allow.Should().BeEquivalentTo( "GET" );
+            content.Error.Should().BeEquivalentTo(
+                new
+                {
+                    Code = "UnsupportedApiVersion",
+                    InnerError = default( OneApiInnerError ),
+                    Message = "The HTTP resource that matches the request URI 'http://localhost/api/ping' does not support HTTP method 'POST'."
+                } );
+        }
     }
 }
+

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/OData/Basic/BasicAcceptanceTest.cs
@@ -62,5 +62,22 @@
             response.StatusCode.Should().Be( BadRequest );
             content.Error.Code.Should().Be( "UnsupportedApiVersion" );
         }
+
+        [Fact]
+        public async Task then_the_service_document_should_return_only_path_for_an_unsupported_version()
+        {
+            // arrange
+
+
+            // act
+            var response = await Client.GetAsync( "api?api-version=4.0" );
+            var content = await response.Content.ReadAsAsync<OneApiErrorResponse>();
+
+            // assert
+            response.StatusCode.Should().Be( BadRequest );
+            content.Error.Code.Should().Be( "UnsupportedApiVersion" );
+            content.Error.Message.Should().Contain( "api" );
+            content.Error.Message.Should().NotContain( "?api-version=1.0" );
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/ApiVersionActionSelectorTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/Versioning/ApiVersionActionSelectorTest.cs
@@ -202,6 +202,24 @@
         }
 
         [Fact]
+        public async Task return_only_path_for_unmatched_action()
+        {
+            // arrange
+            var request = new HttpRequestMessage( Post, "api/attributed?api-version=1.0" );
+
+            using ( var server = new WebServer( options => options.ReportApiVersions = true ) )
+            {
+                // act
+                var response = await server.Client.SendAsync( request );
+
+                // assert
+                var content = await  response.Content.ReadAsStringAsync();
+                content.Should().Contain( "api/attributed" );
+                content.Should().NotContain( "?api-version=1.0" );
+            }
+        }
+
+        [Fact]
         public async Task select_best_candidate_should_assume_1X2E0_for_attributeX2Dbased_controller_when_allowed()
         {
             // arrange


### PR DESCRIPTION
To avoid xss reflection attach, the error messages will now render the absolute path omitting the query string