### PR TITLE
Fix OData URL Substitution

### DIFF
--- a/build/file-version.targets
+++ b/build/file-version.targets
@@ -7,7 +7,7 @@
     <MajorAndMinorVersion>$(AssemblyVersion.Split(`.`)[0]).$(AssemblyVersion.Split(`.`)[1])</MajorAndMinorVersion>
     <DaylightSavingTime>$([System.DateTime]::Now.IsDaylightSavingTime())</DaylightSavingTime>
     <FileBuildNumber>$([System.DateTime]::Today.Subtract($([System.DateTime]::Parse("1/1/2000"))).ToString("%d"))</FileBuildNumber>
-    <FileBuildRevision Condition=" '$(DaylightSavingTime)'=='True' " >$([System.Convert]::ToInt32($([MSBuild]::Divide($([System.DateTime]::Now.TimeOfDay.Subtract($([System.TimeSpan]::FromHours(1.0))).TotalSeconds),2))))</FileBuildRevision>
+    <FileBuildRevision Condition=" '$(DaylightSavingTime)'=='True' " >$([System.Convert]::ToInt32($([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.TimeSpan]::FromHours(1.0))).TimeOfDay.TotalSeconds),2))))</FileBuildRevision>
     <FileBuildRevision Condition=" '$(DaylightSavingTime)'=='False' " >$([System.Convert]::ToInt32($([MSBuild]::Divide($([System.DateTime]::Now.TimeOfDay.TotalSeconds),2))))</FileBuildRevision>
     <FileVersion>$(MajorAndMinorVersion).$(FileBuildNumber).$(FileBuildRevision)</FileVersion>
   </PropertyGroup>

--- a/samples/webapi/AdvancedODataWebApiSample/Startup.cs
+++ b/samples/webapi/AdvancedODataWebApiSample/Startup.cs
@@ -2,12 +2,14 @@
 
 namespace Microsoft.Examples
 {
-    using Configuration;
     using global::Owin;
+    using Microsoft.AspNet.OData;
     using Microsoft.AspNet.OData.Batch;
     using Microsoft.AspNet.OData.Builder;
     using Microsoft.AspNet.OData.Routing;
+    using Microsoft.Examples.Configuration;
     using Microsoft.OData;
+    using Microsoft.OData.UriParser;
     using Microsoft.Web.Http.Versioning;
     using System.Web.Http;
     using static Microsoft.OData.ODataUrlKeyDelimiter;
@@ -33,7 +35,6 @@ namespace Microsoft.Examples
 
             var modelBuilder = new VersionedODataModelBuilder( configuration )
             {
-                ModelBuilderFactory = () => new ODataConventionModelBuilder().EnableLowerCamelCase(),
                 ModelConfigurations =
                 {
                     new PersonModelConfiguration(),
@@ -43,14 +44,15 @@ namespace Microsoft.Examples
             var models = modelBuilder.GetEdmModels();
             var batchHandler = new DefaultODataBatchHandler( httpServer );
 
-            configuration.MapVersionedODataRoutes( "odata", "api", models, OnConfigureContainer, batchHandler );
+            configuration.MapVersionedODataRoutes( "odata", "api", models, ConfigureContainer, batchHandler );
             configuration.Routes.MapHttpRoute( "orders", "api/{controller}/{id}", new { id = Optional } );
             appBuilder.UseWebApi( httpServer );
         }
 
-        static void OnConfigureContainer( IContainerBuilder builder )
+        static void ConfigureContainer( IContainerBuilder builder )
         {
-            builder.AddService( Singleton, typeof( IODataPathHandler ), sp => new DefaultODataPathHandler() { UrlKeyDelimiter = Parentheses } );
+            builder.AddService<IODataPathHandler>( Singleton, sp => new DefaultODataPathHandler() { UrlKeyDelimiter = Parentheses } );
+            builder.AddService<ODataUriResolver>( Singleton, sp => new UnqualifiedCallAndEnumPrefixFreeResolver() { EnableCaseInsensitive = true } );
         }
     }
 }

--- a/samples/webapi/ConventionsODataWebApiSample/Startup.cs
+++ b/samples/webapi/ConventionsODataWebApiSample/Startup.cs
@@ -2,13 +2,19 @@
 
 namespace Microsoft.Examples
 {
-    using Configuration;
-    using Controllers;
     using global::Owin;
+    using Microsoft.AspNet.OData;
     using Microsoft.AspNet.OData.Batch;
     using Microsoft.AspNet.OData.Builder;
+    using Microsoft.AspNet.OData.Routing;
+    using Microsoft.Examples.Configuration;
+    using Microsoft.Examples.Controllers;
+    using Microsoft.OData;
+    using Microsoft.OData.UriParser;
     using Microsoft.Web.Http.Versioning.Conventions;
     using System.Web.Http;
+    using static Microsoft.OData.ODataUrlKeyDelimiter;
+    using static Microsoft.OData.ServiceLifetime;
 
     public class Startup
     {
@@ -38,7 +44,6 @@ namespace Microsoft.Examples
 
             var modelBuilder = new VersionedODataModelBuilder( configuration )
             {
-                ModelBuilderFactory = () => new ODataConventionModelBuilder().EnableLowerCamelCase(),
                 ModelConfigurations =
                 {
                     new PersonModelConfiguration(),
@@ -48,9 +53,15 @@ namespace Microsoft.Examples
             var models = modelBuilder.GetEdmModels();
             var batchHandler = new DefaultODataBatchHandler( httpServer );
 
-            configuration.MapVersionedODataRoutes( "odata", "api", models, batchHandler );
-            configuration.MapVersionedODataRoutes( "odata-bypath", "v{apiVersion}", models );
+            configuration.MapVersionedODataRoutes( "odata", "api", models, ConfigureContainer, batchHandler );
+            configuration.MapVersionedODataRoutes( "odata-bypath", "v{apiVersion}", models, ConfigureContainer );
             appBuilder.UseWebApi( httpServer );
+        }
+
+        static void ConfigureContainer( IContainerBuilder builder )
+        {
+            builder.AddService<IODataPathHandler>( Singleton, sp => new DefaultODataPathHandler() { UrlKeyDelimiter = Parentheses } );
+            builder.AddService<ODataUriResolver>( Singleton, sp => new UnqualifiedCallAndEnumPrefixFreeResolver() { EnableCaseInsensitive = true } );
         }
     }
 }

--- a/samples/webapi/SwaggerODataWebApiSample/Configuration/OrderModelConfiguration.cs
+++ b/samples/webapi/SwaggerODataWebApiSample/Configuration/OrderModelConfiguration.cs
@@ -30,12 +30,12 @@
 
             if ( apiVersion >= ApiVersions.V1 )
             {
-                // order.Collection.Function( "MostExpensive" ).ReturnsFromEntitySet<Order>( "Orders" );
+                order.Collection.Function( "MostExpensive" ).ReturnsFromEntitySet<Order>( "Orders" );
             }
 
             if ( apiVersion >= ApiVersions.V2 )
             {
-                //order.Action( "Rate" ).Parameter<int>( "rating" );
+                order.Action( "Rate" ).Parameter<int>( "rating" );
             }
         }
     }

--- a/samples/webapi/SwaggerODataWebApiSample/SwaggerODataWebApiSample.csproj
+++ b/samples/webapi/SwaggerODataWebApiSample/SwaggerODataWebApiSample.csproj
@@ -84,9 +84,6 @@
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Swashbuckle.Core.5.5.3\lib\net40\Swashbuckle.Core.dll</HintPath>
     </Reference>
-    <!--<Reference Include="Swashbuckle.OData, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a2e252c86e553959, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Swashbuckle.OData.3.2.0\lib\net452\Swashbuckle.OData.dll</HintPath>
-    </Reference>-->
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
@@ -178,7 +175,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>1874</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:1874/</IISUrl>
+          <IISUrl>http://localhost:1874/swagger</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/src/Common.ApiExplorer/ApiExplorerOptions.cs
+++ b/src/Common.ApiExplorer/ApiExplorerOptions.cs
@@ -53,5 +53,22 @@ namespace Microsoft.AspNetCore.Mvc.ApiExplorer
         /// <value>The default description for API version parameters. The default value
         /// is "The requested API version".</value>
         public string DefaultApiVersionParameterDescription { get; set; } = LocalSR.DefaultApiVersionParamDesc;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether API version parameters are added when an API is version-neutral.
+        /// </summary>
+        /// <value>True if API version parameters should be included when exploring a version-neutral API; otherwise, false.
+        /// The default value is <c>false</c>.</value>
+        /// <remarks>
+        /// <para>
+        /// A version-neutral API can accept any API version, including none at all. Setting this property to true
+        /// will enable exploring parameter descriptors for an API version that can be used to generate user input, which
+        /// may be useful for a version-neutral API that its own per-API version logic.
+        /// </para>
+        /// <para>
+        /// An API version defined using the URLsegment method is unaffected by this setting because path-based route
+        /// parameters are always required.
+        /// </para></remarks>
+        public bool AddApiVersionParametersWhenVersionNeutral { get; set; }
     }
 }

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DeclaringType.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DeclaringType.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.AspNet.OData
+{
+    using System;
+
+    struct DeclaringType
+    {
+        internal static Type Value = typeof( DeclaringType );
+    }
+}

--- a/src/Common.OData.ApiExplorer/AspNet.OData/EdmTypeKey.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/EdmTypeKey.cs
@@ -1,0 +1,51 @@
+﻿namespace Microsoft.AspNet.OData
+{
+#if !WEBAPI
+    using Microsoft.AspNetCore.Mvc;
+#endif
+    using Microsoft.OData.Edm;
+#if WEBAPI
+    using Microsoft.Web.Http;
+#endif
+    using System;
+    using System.Diagnostics.Contracts;
+
+    struct EdmTypeKey : IEquatable<EdmTypeKey>
+    {
+        readonly int hashCode;
+
+        internal EdmTypeKey( IEdmStructuredType type, ApiVersion apiVersion )
+        {
+            Contract.Requires( type != null );
+            Contract.Requires( apiVersion != null );
+
+            hashCode = ComputeHash( type.FullTypeName(), apiVersion );
+        }
+
+        internal EdmTypeKey( IEdmTypeReference type, ApiVersion apiVersion )
+        {
+            Contract.Requires( type != null );
+            Contract.Requires( apiVersion != null );
+
+            hashCode = ComputeHash( type.FullName(), apiVersion );
+        }
+
+        public static bool operator ==( EdmTypeKey obj, EdmTypeKey other ) => obj.Equals( other );
+
+        public static bool operator !=( EdmTypeKey obj, EdmTypeKey other ) => !obj.Equals( other );
+
+        public override int GetHashCode() => hashCode;
+
+        public override bool Equals( object obj ) => obj is EdmTypeKey other && Equals( other );
+
+        public bool Equals( EdmTypeKey other ) => hashCode == other.hashCode;
+
+        static int ComputeHash( string fullName, ApiVersion apiVersion )
+        {
+            Contract.Requires( !string.IsNullOrEmpty( fullName ) );
+            Contract.Requires( apiVersion != null );
+
+            return ( fullName.GetHashCode() * 397 ) ^ apiVersion.GetHashCode();
+        }
+    }
+}

--- a/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
@@ -80,7 +80,7 @@
                 return;
             }
 
-            prefix = UpdateRoutePrefixAndRemoveApiVersionParameterIfNecessary( prefix );
+            prefix = RemoveRouteConstraints( prefix );
             segments.Add( prefix );
         }
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/TypeExtensions.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/TypeExtensions.cs
@@ -82,6 +82,25 @@
             item2 = tuple.Item2;
         }
 
+        internal static bool IsDeclaringType( this Type type )
+        {
+            Contract.Requires( type != null );
+
+            if ( type == DeclaringType.Value )
+            {
+                return true;
+            }
+
+            if ( !type.IsGenericType )
+            {
+                return false;
+            }
+
+            var typeArgs = type.GetGenericArguments();
+
+            return typeArgs.Length == 1 && typeArgs[0] == DeclaringType.Value;
+        }
+
         static bool IsSubstitutableGeneric( Type type, Stack<Type> openTypes, out Type innerType )
         {
             Contract.Requires( type != null );

--- a/src/Common.OData.ApiExplorer/Common.OData.ApiExplorer.projitems
+++ b/src/Common.OData.ApiExplorer/Common.OData.ApiExplorer.projitems
@@ -11,6 +11,8 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\ClassProperty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\ClassSignature.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\DeclaringType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\EdmTypeKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\IModelTypeBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\DefaultModelTypeBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\ODataValue{T}.cs" />

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
@@ -1,37 +1,9 @@
 ﻿namespace Microsoft.AspNet.OData.Routing
 {
-    using Microsoft.Web.Http.Description;
-    using System.Diagnostics.Contracts;
-    using System.Linq;
-    using static System.Globalization.CultureInfo;
+    using System;
 
     partial class ODataRouteBuilder
     {
-        string UpdateRoutePrefixAndRemoveApiVersionParameterIfNecessary( string routePrefix )
-        {
-            Contract.Requires( !string.IsNullOrEmpty( routePrefix ) );
-            Contract.Ensures( !string.IsNullOrEmpty( Contract.Result<string>() ) );
-
-            var parameters = Context.ParameterDescriptions;
-            var parameter = parameters.FirstOrDefault( p => p.ParameterDescriptor is ApiVersionParameterDescriptor pd && pd.FromPath );
-
-            if ( parameter == null )
-            {
-                return routePrefix;
-            }
-
-            var apiVersionFormat = Context.Options.SubstitutionFormat;
-            var token = string.Concat( '{', parameter.Name, '}' );
-            var value = Context.ApiVersion.ToString( apiVersionFormat, InvariantCulture );
-            var newRoutePrefix = routePrefix.Replace( token, value );
-
-            if ( routePrefix == newRoutePrefix )
-            {
-                return routePrefix;
-            }
-
-            parameters.Remove( parameter );
-            return newRoutePrefix;
-        }
+        static string RemoveRouteConstraints( string routePrefix ) => routePrefix;
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/ApiDescriptionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/ApiDescriptionExtensions.cs
@@ -3,7 +3,11 @@
     using System;
     using System.ComponentModel;
     using System.Diagnostics.Contracts;
+    using System.Linq;
+    using static Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource;
     using static System.ComponentModel.EditorBrowsableState;
+    using static System.Globalization.CultureInfo;
+    using static System.Linq.Enumerable;
 
     /// <summary>
     /// Provides extension methods for the <see cref="ApiDescription"/> class.
@@ -25,6 +29,44 @@
         /// <param name="apiVersion">The associated <see cref="ApiVersion">API version</see>.</param>
         [EditorBrowsable( Never )]
         public static void SetApiVersion( this ApiDescription apiDescription, ApiVersion apiVersion ) => apiDescription.SetProperty( apiVersion );
+
+        /// <summary>
+        /// Attempts to update the relate path of the specified API description and remove the corresponding parameter according to the specified options.
+        /// </summary>
+        /// <param name="apiDescription">The <see cref="ApiDescription">API description</see> to attempt to update.</param>
+        /// <param name="options">The current <see cref="ApiExplorerOptions">API Explorer options</see>.</param>
+        /// <returns>True if the <paramref name="apiDescription">API description</paramref> was updated; otherwise, false.</returns>
+        public static bool TryUpdateRelativePathAndRemoveApiVersionParameter( this ApiDescription apiDescription, ApiExplorerOptions options )
+        {
+            Arg.NotNull( apiDescription, nameof( apiDescription ) );
+            Arg.NotNull( options, nameof( options ) );
+
+            if ( !options.SubstituteApiVersionInUrl )
+            {
+                return false;
+            }
+
+            var parameter = apiDescription.ParameterDescriptions.FirstOrDefault( pd => pd.Source == Path && pd.ModelMetadata?.DataTypeName == nameof( ApiVersion ) );
+
+            if ( parameter == null )
+            {
+                return false;
+            }
+
+            var relativePath = apiDescription.RelativePath;
+            var token = '{' + parameter.Name + '}';
+            var value = apiDescription.GetApiVersion().ToString( options.SubstitutionFormat, InvariantCulture );
+            var newRelativePath = relativePath.Replace( token, value );
+
+            if ( relativePath == newRelativePath )
+            {
+                return false;
+            }
+
+            apiDescription.RelativePath = newRelativePath;
+            apiDescription.ParameterDescriptions.Remove( parameter );
+            return true;
+        }
 
         /// <summary>
         /// Creates a shallow copy of the current API description.

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/PseudoModelBindingVisitor.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/PseudoModelBindingVisitor.cs
@@ -24,11 +24,11 @@
 
         internal ParameterDescriptor Parameter { get; }
 
-        private HashSet<PropertyKey> Visited { get; } = new HashSet<PropertyKey>( new PropertyKeyEqualityComparer() );
+        HashSet<PropertyKey> Visited { get; } = new HashSet<PropertyKey>( new PropertyKeyEqualityComparer() );
 
         internal void WalkParameter( ApiParameterDescriptionContext context ) => Visit( context, BindingSource.ModelBinding, containerName: string.Empty );
 
-        private static string GetName( string containerName, ApiParameterDescriptionContext metadata )
+        static string GetName( string containerName, ApiParameterDescriptionContext metadata )
         {
             if ( string.IsNullOrEmpty( metadata.BinderModelName ) )
             {
@@ -38,7 +38,7 @@
             return metadata.BinderModelName;
         }
 
-        private void Visit( ApiParameterDescriptionContext bindingContext, BindingSource ambientSource, string containerName )
+        void Visit( ApiParameterDescriptionContext bindingContext, BindingSource ambientSource, string containerName )
         {
             var source = bindingContext.BindingSource;
 

--- a/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBuilder.Core.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBuilder.Core.cs
@@ -1,6 +1,8 @@
 ﻿namespace Microsoft.AspNet.OData.Routing
 {
+    using Microsoft.AspNetCore.Routing.Template;
     using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
     using static System.String;
 
     partial class ODataRouteBuilder
@@ -19,6 +21,34 @@
             return Join( "/", segments );
         }
 
-        static string UpdateRoutePrefixAndRemoveApiVersionParameterIfNecessary( string routePrefix ) => routePrefix;
+        static string RemoveRouteConstraints( string routePrefix )
+        {
+            Contract.Requires( !IsNullOrEmpty( routePrefix ) );
+            Contract.Ensures( !IsNullOrEmpty( Contract.Result<string>() ) );
+
+            var parsedTemplate = TemplateParser.Parse( routePrefix );
+            var segments = new List<string>( parsedTemplate.Segments.Count );
+
+            foreach ( var segment in parsedTemplate.Segments )
+            {
+                var currentSegment = Empty;
+
+                foreach ( var part in segment.Parts )
+                {
+                    if ( part.IsLiteral )
+                    {
+                        currentSegment += part.Text;
+                    }
+                    else if ( part.IsParameter )
+                    {
+                        currentSegment += Concat( "{", part.Name, "}" );
+                    }
+                }
+
+                segments.Add( currentSegment );
+            }
+
+            return Join( "/", segments );
+        }
     }
 }

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Company.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Company.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.AspNet.OData
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class Company
+    {
+        public int CompanyId { get; set; }
+
+        public Company ParentCompany { get; set; }
+
+        public List<Company> Subsidiaries { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime DateFounded { get; set; }
+    }
+}

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/Description/ApiVersionParameterDescriptionContextTest.cs
@@ -1,13 +1,16 @@
 ﻿namespace Microsoft.Web.Http.Description
 {
     using FluentAssertions;
+    using Microsoft.Web.Http.Versioning;
     using Moq;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Net.Http.Formatting;
     using System.Net.Http.Headers;
     using System.Web.Http;
     using System.Web.Http.Controllers;
     using System.Web.Http.Description;
+    using System.Web.Http.Filters;
     using Xunit;
     using static Microsoft.Web.Http.Versioning.ApiVersionParameterLocation;
     using static System.Web.Http.Description.ApiParameterSource;
@@ -19,7 +22,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -54,7 +57,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -89,7 +92,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -125,7 +128,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -147,7 +150,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -169,7 +172,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var json = new JsonMediaTypeFormatter();
             var formUrlEncoded = new FormUrlEncodedMediaTypeFormatter();
 
@@ -214,7 +217,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -251,7 +254,7 @@
         {
             // arrange
             var configuration = new HttpConfiguration();
-            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var action = NewActionDescriptor();
             var description = new ApiDescription() { ActionDescriptor = action };
             var version = new ApiVersion( 1, 0 );
             var options = new ApiExplorerOptions( configuration );
@@ -266,6 +269,19 @@
             // assert
             description.ParameterDescriptions[0].ParameterDescriptor.IsOptional.Should().BeFalse();
             description.ParameterDescriptions[1].ParameterDescriptor.IsOptional.Should().BeTrue();
+        }
+
+        static HttpActionDescriptor NewActionDescriptor()
+        {
+            var action = new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+            var controller = new Mock<HttpControllerDescriptor>() { CallBase = true };
+
+            controller.Setup( c => c.GetCustomAttributes<IApiVersionProvider>( It.IsAny<bool>() ) ).Returns( new Collection<IApiVersionProvider>() );
+            controller.Setup( c => c.GetCustomAttributes<IApiVersionNeutral>( It.IsAny<bool>() ) ).Returns( new Collection<IApiVersionNeutral>() );
+            controller.Setup( c => c.GetFilters() ).Returns( new Collection<IFilter>() );
+            action.ControllerDescriptor = controller.Object;
+
+            return action;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/ApiVersionParameterDescriptionContextTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.Tests/ApiVersionParameterDescriptionContextTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
     using FluentAssertions;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
     using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
     using Microsoft.AspNetCore.Mvc.Routing;
@@ -18,8 +19,8 @@
         public void add_parameter_should_add_descriptor_for_query_parameter()
         {
             // arrange
-            var description = new ApiDescription();
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -52,8 +53,8 @@
         public void add_parameter_should_add_descriptor_for_header()
         {
             // arrange
-            var description = new ApiDescription();
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -95,8 +96,8 @@
                 },
                 Source = BindingSource.Path
             };
-            var description = new ApiDescription() { ParameterDescriptions = { parameter } };
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version, parameter );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -139,8 +140,8 @@
                 },
                 Source = BindingSource.Path
             };
-            var description = new ApiDescription() { ParameterDescriptions = { parameter } };
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version, parameter );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -186,8 +187,8 @@
                 },
                 Source = BindingSource.Path
             };
-            var description = new ApiDescription() { ParameterDescriptions = { parameter } };
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version, parameter );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -211,24 +212,25 @@
         {
             // arrange
             const string Json = "application/json";
+            var version = new ApiVersion( 1, 0 );
             var description = new ApiDescription()
             {
+                ActionDescriptor = new ActionDescriptor() { Properties = { [typeof( ApiVersionModel )] = new ApiVersionModel( version ) } },
                 SupportedRequestFormats =
                 {
-                    new ApiRequestFormat() { MediaType = Json }
+                new ApiRequestFormat() { MediaType = Json }
                 },
                 SupportedResponseTypes =
                 {
-                    new ApiResponseType()
-                    {
-                        ApiResponseFormats =
+                new ApiResponseType()
+                {
+                    ApiResponseFormats =
                         {
                             new ApiResponseFormat() { MediaType = Json }
                         }
-                    }
+                }
                 }
             };
-            var version = new ApiVersion( 1, 0 );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -249,8 +251,8 @@
         public void add_parameter_should_add_optional_parameter_when_allowed()
         {
             // arrange
-            var description = new ApiDescription();
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -284,8 +286,8 @@
         public void add_parameter_should_make_parameters_optional_after_first_parameter()
         {
             // arrange
-            var description = new ApiDescription();
             var version = new ApiVersion( 1, 0 );
+            var description = NewApiDescription( version );
             var modelMetadata = new Mock<ModelMetadata>( ModelMetadataIdentity.ForType( typeof( string ) ) );
             var options = new ApiExplorerOptions()
             {
@@ -301,6 +303,22 @@
             // assert
             description.ParameterDescriptions[0].RouteInfo.IsOptional.Should().BeFalse();
             description.ParameterDescriptions[1].RouteInfo.IsOptional.Should().BeTrue();
+        }
+
+        static ApiDescription NewApiDescription( ApiVersion apiVersion, params ApiParameterDescription[] parameters )
+        {
+            var description = new ApiDescription();
+            var action = new ActionDescriptor();
+
+            action.SetProperty( new ApiVersionModel( apiVersion ) );
+            description.ActionDescriptor = action;
+
+            foreach ( var parameter in parameters )
+            {
+                description.ParameterDescriptions.Add( parameter );
+            }
+
+            return description;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Company.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Company.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.AspNet.OData
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class Company
+    {
+        public int CompanyId { get; set; }
+
+        public Company ParentCompany { get; set; }
+
+        public List<Company> Subsidiaries { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime DateFounded { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes the parsing and substitution of route prefixes for the OData API Explorer. Also enables the optional inclusion of API version parameters for version-neutral actions (normally excluded).

Fixes #365