### PR TITLE
Support substitution with dependencies

### DIFF
--- a/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
@@ -38,17 +38,8 @@
 
         public override int GetHashCode() => ( Name.GetHashCode() * 397 ) ^ type.GetHashCode();
 
-        public Type GetType( Type declaringType )
+        public Type GetPropertyType()
         {
-            Contract.Requires( declaringType != null );
-            Contract.Ensures( Contract.Result<Type>() != null );
-
-            if ( type.IsGenericType )
-            {
-                var typeArgs = type.GetGenericArguments();
-                return type.GetGenericTypeDefinition().MakeGenericType( declaringType );
-            }
-
             return type;
         }
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
@@ -43,18 +43,10 @@
             Contract.Requires( declaringType != null );
             Contract.Ensures( Contract.Result<Type>() != null );
 
-            if ( type == DeclaringType.Value )
-            {
-                return declaringType;
-            }
-            else if ( type.IsGenericType )
+            if ( type.IsGenericType )
             {
                 var typeArgs = type.GetGenericArguments();
-
-                if ( typeArgs.Length == 1 && typeArgs[0] == DeclaringType.Value )
-                {
-                    return type.GetGenericTypeDefinition().MakeGenericType( declaringType );
-                }
+                return type.GetGenericTypeDefinition().MakeGenericType( declaringType );
             }
 
             return type;

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DeclaringType.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DeclaringType.cs
@@ -1,9 +1,0 @@
-﻿namespace Microsoft.AspNet.OData
-{
-    using System;
-
-    struct DeclaringType
-    {
-        internal static Type Value = typeof( DeclaringType );
-    }
-}

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -136,7 +136,7 @@
                     }
                 }
 
-                clrTypeMatchesEdmType &= propertyType.IsDeclaringType() || property.PropertyType.Equals( propertyType );
+                clrTypeMatchesEdmType &= property.PropertyType.Equals( propertyType );
                 properties.Add( new ClassProperty( property, propertyType ) );
             }
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -113,6 +113,7 @@
                         if ( !itemType.Equals( newItemType ) )
                         {
                             propertyType = IEnumerableOfT.MakeGenericType( newItemType );
+                            clrTypeMatchesEdmType = false;
                         }
                     }
                 }
@@ -201,7 +202,7 @@
 
             foreach ( var property in @class.Properties )
             {
-                var type = property.GetType( typeBuilder );
+                var type = property.GetPropertyType();
                 var name = property.Name;
                 var propertyBuilder = AddProperty( typeBuilder, type, name );
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -67,7 +67,7 @@
             var structuralProperties = structuredType.Properties().ToDictionary( p => p.Name, StringComparer.OrdinalIgnoreCase );
             var clrTypeMatchesEdmType = true;
             var hasUnfinishedTypes = false;
-            var dependentProperties = new Dictionary<string, Tuple<EdmTypeKey, bool>>();
+            var dependentProperties = new List<Tuple<EdmTypeKey, bool, string>>();
 
             foreach ( var property in clrType.GetProperties( bindingFlags ) )
             {
@@ -98,8 +98,8 @@
                         {
                             clrTypeMatchesEdmType = false;
                             hasUnfinishedTypes = true;
-                            var keyTuple = new Tuple<EdmTypeKey, bool>( elementKey, true );
-                            dependentProperties.Add(property.Name,  keyTuple );
+                            var dependencyTuple = new Tuple<EdmTypeKey, bool, string>( elementKey, true, property.Name );
+                            dependentProperties.Add( dependencyTuple );
                             continue;
                         }
 
@@ -130,8 +130,8 @@
                     {
                         clrTypeMatchesEdmType = false;
                         hasUnfinishedTypes = true;
-                        var keyTuple = new Tuple<EdmTypeKey, bool>( propertyTypeKey, false );
-                        dependentProperties.Add(property.Name, keyTuple );
+                        var dependencyTuple = new Tuple<EdmTypeKey, bool, string>( propertyTypeKey, false, property.Name );
+                        dependentProperties.Add( dependencyTuple );
                         continue;
                     }
                 }
@@ -153,10 +153,9 @@
                 {
                     typeBuilder = CreateTypeBuilderFromSignature( signature );
                     var newPropertyDependencies = new List<PropertyDependency>();
-                    foreach ( var name in dependentProperties.Keys )
+                    foreach ( var dependencyTuple in dependentProperties )
                     {
-                        var keyTuple = dependentProperties[name];
-                        newPropertyDependencies.Add( new PropertyDependency( typeBuilder, keyTuple.Item1, name, keyTuple.Item2 ) );
+                        newPropertyDependencies.Add( new PropertyDependency( typeBuilder, dependencyTuple.Item1, dependencyTuple.Item2, dependencyTuple.Item3 ) );
                     }
 
                     dependencies.Add( typeKey, newPropertyDependencies );

--- a/src/Common.OData.ApiExplorer/AspNet.OData/PropertyDependency.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/PropertyDependency.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.OData
         /// <param name="dependentOnTypeKey">The key of the type the property has a dependency on.</param>
         /// <param name="propertyName">The name of the property.</param>
         /// <param name="isCollection">Whether the property is a collection or not.</param>
-        internal PropertyDependency( TypeBuilder dependentType, EdmTypeKey dependentOnTypeKey, string propertyName, bool isCollection )
+        internal PropertyDependency( TypeBuilder dependentType, EdmTypeKey dependentOnTypeKey,  bool isCollection, string propertyName )
         {
             Arg.NotNull<TypeBuilder>( dependentType, nameof(dependentType) );
             Arg.NotNull<EdmTypeKey>( dependentOnTypeKey, nameof( dependentOnTypeKey ) );

--- a/src/Common.OData.ApiExplorer/AspNet.OData/PropertyDependency.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/PropertyDependency.cs
@@ -1,0 +1,49 @@
+namespace Microsoft.AspNet.OData
+{
+    using System.Reflection.Emit;
+
+    /// <summary>
+    /// Represents a dependency on a type of a property that has not been built yet.
+    /// </summary>
+    internal class PropertyDependency
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyDependency"/> class.
+        /// </summary>
+        /// <param name="dependentType">The type that contains the dependent property.</param>
+        /// <param name="dependentOnTypeKey">The key of the type the property has a dependency on.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <param name="isCollection">Whether the property is a collection or not.</param>
+        internal PropertyDependency( TypeBuilder dependentType, EdmTypeKey dependentOnTypeKey, string propertyName, bool isCollection )
+        {
+            Arg.NotNull<TypeBuilder>( dependentType, nameof(dependentType) );
+            Arg.NotNull<EdmTypeKey>( dependentOnTypeKey, nameof( dependentOnTypeKey ) );
+            Arg.NotNull<string>( propertyName, nameof( propertyName ) );
+
+            DependentType = dependentType;
+            DependentOnTypeKey = dependentOnTypeKey;
+            PropertyName = propertyName;
+            IsCollection = isCollection;
+        }
+
+        /// <summary>
+        /// Gets the type that has a dependent property.
+        /// </summary>
+        internal TypeBuilder DependentType { get; }
+
+        /// <summary>
+        /// Gets the key of the type the property has a dependency on.
+        /// </summary>
+        internal EdmTypeKey DependentOnTypeKey { get; }
+
+        /// <summary>
+        /// Gets the name of the property.
+        /// </summary>
+        internal string PropertyName { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the property is a collection.
+        /// </summary>
+        internal bool IsCollection { get; }
+    }
+}

--- a/src/Common.OData.ApiExplorer/AspNet.OData/PropertyDependency.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/PropertyDependency.cs
@@ -10,26 +10,23 @@ namespace Microsoft.AspNet.OData
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyDependency"/> class.
         /// </summary>
-        /// <param name="dependentType">The type that contains the dependent property.</param>
         /// <param name="dependentOnTypeKey">The key of the type the property has a dependency on.</param>
         /// <param name="propertyName">The name of the property.</param>
         /// <param name="isCollection">Whether the property is a collection or not.</param>
-        internal PropertyDependency( TypeBuilder dependentType, EdmTypeKey dependentOnTypeKey,  bool isCollection, string propertyName )
+        internal PropertyDependency( EdmTypeKey dependentOnTypeKey,  bool isCollection, string propertyName )
         {
-            Arg.NotNull<TypeBuilder>( dependentType, nameof(dependentType) );
             Arg.NotNull<EdmTypeKey>( dependentOnTypeKey, nameof( dependentOnTypeKey ) );
             Arg.NotNull<string>( propertyName, nameof( propertyName ) );
 
-            DependentType = dependentType;
             DependentOnTypeKey = dependentOnTypeKey;
             PropertyName = propertyName;
             IsCollection = isCollection;
         }
 
         /// <summary>
-        /// Gets the type that has a dependent property.
+        /// Gets or sets the type that has a dependent property.
         /// </summary>
-        internal TypeBuilder DependentType { get; }
+        internal TypeBuilder DependentType { get; set;  }
 
         /// <summary>
         /// Gets the key of the type the property has a dependency on.

--- a/src/Common.OData.ApiExplorer/AspNet.OData/TypeExtensions.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/TypeExtensions.cs
@@ -82,25 +82,6 @@
             item2 = tuple.Item2;
         }
 
-        internal static bool IsDeclaringType( this Type type )
-        {
-            Contract.Requires( type != null );
-
-            if ( type == DeclaringType.Value )
-            {
-                return true;
-            }
-
-            if ( !type.IsGenericType )
-            {
-                return false;
-            }
-
-            var typeArgs = type.GetGenericArguments();
-
-            return typeArgs.Length == 1 && typeArgs[0] == DeclaringType.Value;
-        }
-
         static bool IsSubstitutableGeneric( Type type, Stack<Type> openTypes, out Type innerType )
         {
             Contract.Requires( type != null );

--- a/src/Common.OData.ApiExplorer/Common.OData.ApiExplorer.projitems
+++ b/src/Common.OData.ApiExplorer/Common.OData.ApiExplorer.projitems
@@ -11,7 +11,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\ClassProperty.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\ClassSignature.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\DeclaringType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\EdmTypeKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\IModelTypeBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\DefaultModelTypeBuilder.cs" />

--- a/src/Common.OData.ApiExplorer/Common.OData.ApiExplorer.projitems
+++ b/src/Common.OData.ApiExplorer/Common.OData.ApiExplorer.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\IModelTypeBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\DefaultModelTypeBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\ODataValue{T}.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\PropertyDependency.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\Routing\ODataRouteActionType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\Routing\ODataRouteBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AspNet.OData\Routing\ODataRouteBuilderContext.cs" />

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
@@ -133,24 +133,6 @@
         }
 
         [Fact]
-        public void type_should_match_with_self_referencing_property_substitution()
-        {
-            // arrange
-            var modelBuilder = new ODataConventionModelBuilder();
-
-            modelBuilder.EntitySet<Company>( "Companies" );
-
-            var context = NewContext( modelBuilder.GetEdmModel() );
-            var originalType = typeof( Company );
-
-            //act
-            var subsitutedType = originalType.SubstituteIfNecessary( context );
-
-            // assert
-            subsitutedType.Should().Be( typeof( Company ) );
-        }
-
-        [Fact]
         public void type_should_use_self_referencing_property_substitution()
         {
             // arrange

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employee.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employee.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.AspNet.OData
+{
+    public class Employee
+    {
+        public int EmployeeId { get; set; }
+        
+        public Employer Employer { get; set; }
+
+        public decimal Salary { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.OData
+{
+    public class Employer
+    {
+        public int EmployerId { get; set; }
+
+        public ICollection<Employee> Employees { get; set; }
+        
+        public DateTime Birthday { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
@@ -133,24 +133,6 @@
         }
 
         [Fact]
-        public void type_should_match_with_self_referencing_property_substitution()
-        {
-            // arrange
-            var modelBuilder = new ODataConventionModelBuilder();
-
-            modelBuilder.EntitySet<Company>( "Companies" );
-
-            var context = NewContext( modelBuilder.GetEdmModel() );
-            var originalType = typeof( Company );
-
-            //act
-            var subsitutedType = originalType.SubstituteIfNecessary( context );
-
-            // assert
-            subsitutedType.Should().Be( typeof( Company ) );
-        }
-
-        [Fact]
         public void type_should_use_self_referencing_property_substitution()
         {
             // arrange

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employee.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employee.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.AspNet.OData
+{
+    public class Employee
+    {
+        public int EmployeeId { get; set; }
+        
+        public Employer Employer { get; set; }
+
+        public decimal Salary { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.OData
+{
+    public class Employer
+    {
+        public int EmployerId { get; set; }
+
+        public ICollection<Employee> Employees { get; set; }
+        
+        public DateTime Birthday { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+    }
+}


### PR DESCRIPTION
Allow the substitution of structured types that have references to types that are still being built.
This supports self-references but also adds support for backreferences or circular references.

Removed the NewStructuredTypeOrSelf methods because the dependency resolver will handle this now.

Note: I removed the type_should_match_with_self_referencing_property_substition test because with the current implementation if there is a self-reference or back reference the type will always be dynamically built.