### PR TITLE
Add support for action parameters with collection parameters

### DIFF
--- a/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
@@ -30,7 +30,18 @@
             Contract.Requires( parameter != null );
 
             Name = parameter.Name;
-            type = parameter.Type.Definition.GetClrType( assemblies );
+
+            if ( parameter.Type.IsCollection() )
+            {
+                var collectionType = parameter.Type.AsCollection();
+                var elementType = collectionType.ElementType().Definition.GetClrType( assemblies );
+                type = typeof( IEnumerable<> ).MakeGenericType( elementType );
+            }
+            else
+            {
+                type = parameter.Type.Definition.GetClrType( assemblies );
+            }
+
             Attributes = AttributesFromOperationParameter( parameter );
         }
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/ClassProperty.cs
@@ -11,7 +11,7 @@
 
     struct ClassProperty
     {
-        readonly Type type;
+        internal readonly Type Type;
         internal readonly string Name;
 
         internal ClassProperty( PropertyInfo clrProperty, Type propertyType )
@@ -20,14 +20,16 @@
             Contract.Requires( propertyType != null );
 
             Name = clrProperty.Name;
-            type = propertyType;
+            Type = propertyType;
             Attributes = AttributesFromProperty( clrProperty );
         }
 
         internal ClassProperty( IServiceProvider services, IEnumerable<Assembly> assemblies, IEdmOperationParameter parameter, IModelTypeBuilder typeBuilder )
         {
+            Contract.Requires( services != null );
             Contract.Requires( assemblies != null );
             Contract.Requires( parameter != null );
+            Contract.Requires( typeBuilder != null );
 
             Name = parameter.Name;
             var context = new TypeSubstitutionContext( services, assemblies, typeBuilder );
@@ -38,13 +40,13 @@
                 var elementType = collectionType.ElementType().Definition.GetClrType( assemblies );
                 var substitutedType = elementType.SubstituteIfNecessary( context );
 
-                type = typeof( IEnumerable<> ).MakeGenericType( substitutedType );
+                Type = typeof( IEnumerable<> ).MakeGenericType( substitutedType );
             }
             else
             {
                 var parameterType = parameter.Type.Definition.GetClrType( assemblies );
 
-                type = parameterType.SubstituteIfNecessary( context );
+                Type = parameterType.SubstituteIfNecessary( context );
             }
 
             Attributes = AttributesFromOperationParameter( parameter );
@@ -52,12 +54,7 @@
 
         internal IEnumerable<CustomAttributeBuilder> Attributes { get; }
 
-        public override int GetHashCode() => ( Name.GetHashCode() * 397 ) ^ type.GetHashCode();
-
-        public Type GetPropertyType()
-        {
-            return type;
-        }
+        public override int GetHashCode() => ( Name.GetHashCode() * 397 ) ^ Type.GetHashCode();
 
         static IEnumerable<CustomAttributeBuilder> AttributesFromProperty( PropertyInfo clrProperty )
         {

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -173,6 +173,7 @@
         /// <inheritdoc />
         public Type NewActionParameters( IServiceProvider services, IEdmAction action, ApiVersion apiVersion )
         {
+            Arg.NotNull( services, nameof( services ) );
             Arg.NotNull( action, nameof( action ) );
             Arg.NotNull( apiVersion, nameof( apiVersion ) );
             Contract.Ensures( Contract.Result<Type>() != null );
@@ -202,7 +203,7 @@
 
             foreach ( var property in @class.Properties )
             {
-                var type = property.GetPropertyType();
+                var type = property.Type;
                 var name = property.Name;
                 var propertyBuilder = AddProperty( typeBuilder, type, name );
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -171,14 +171,14 @@
         }
 
         /// <inheritdoc />
-        public Type NewActionParameters( IEdmAction action, ApiVersion apiVersion )
+        public Type NewActionParameters( IServiceProvider services, IEdmAction action, ApiVersion apiVersion )
         {
             Arg.NotNull( action, nameof( action ) );
             Arg.NotNull( apiVersion, nameof( apiVersion ) );
             Contract.Ensures( Contract.Result<Type>() != null );
 
             var name = action.FullName() + "Parameters";
-            var properties = action.Parameters.Where( p => p.Name != "bindingParameter" ).Select( p => new ClassProperty( assemblies, p ) );
+            var properties = action.Parameters.Where( p => p.Name != "bindingParameter" ).Select( p => new ClassProperty( services, assemblies, p, this ) );
             var signature = new ClassSignature( name, properties, apiVersion );
 
             return CreateTypeInfoFromSignature( signature );

--- a/src/Common.OData.ApiExplorer/AspNet.OData/IModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/IModelTypeBuilder.cs
@@ -29,14 +29,15 @@
         Type NewStructuredType( IEdmStructuredType structuredType, Type clrType, ApiVersion apiVersion );
 
         /// <summary>
-        /// Creates an returns a stronly-typed definition for OData action parameters.
+        /// Creates an returns a strongly-typed definition for OData action parameters.
         /// </summary>
+        /// <param name="services">The <see cref="IServiceProvider">services</see> needed to potentially substitute types.</param>
         /// <param name="action">The defining <see cref="IEdmAction">action</see>.</param>
         /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> of the <paramref name="action"/> to create the parameter type for.</param>
         /// <returns>A strong <see cref="Type">type</see> definition for the OData <paramref name="action"/> parameters.</returns>
         /// <remarks><see cref="ODataActionParameters">OData action parameters</see> are modeled as a <see cref="Dictionary{TKey,TValue}">dictionary</see>,
         /// which is difficult to use effectively by documentation tools such as the API Explorer. The corresponding type is generated only once per
         /// <paramref name="apiVersion">API version</paramref>.</remarks>
-        Type NewActionParameters( IEdmAction action, ApiVersion apiVersion );
+        Type NewActionParameters( IServiceProvider services, IEdmAction action, ApiVersion apiVersion );
     }
 }

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -79,7 +79,7 @@
 
                 if ( parameter.ParameterType.IsODataActionParameters() )
                 {
-                    description.ParameterDescriptor = new ODataModelBoundParameterDescriptor( parameter, modelTypeBuilder.NewActionParameters( action, apiVersion.Value ) );
+                    description.ParameterDescriptor = new ODataModelBoundParameterDescriptor( parameter, modelTypeBuilder.NewActionParameters( serviceProvider, action, apiVersion.Value ) );
                     break;
                 }
             }

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/PseudoModelBindingVisitor.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/PseudoModelBindingVisitor.cs
@@ -88,7 +88,7 @@
             {
                 var action = (IEdmAction) Context.RouteContext.Operation;
                 var apiVersion = Context.RouteContext.ApiVersion;
-                type = Context.TypeBuilder.NewActionParameters( action, apiVersion );
+                type = Context.TypeBuilder.NewActionParameters( Context.Services, action, apiVersion );
             }
             else
             {

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
@@ -1,8 +1,8 @@
-using System;
-using System.Collections.Generic;
-
 namespace Microsoft.AspNet.OData
 {
+    using System;
+    using System.Collections.Generic;
+
     public class Employer
     {
         public int EmployerId { get; set; }

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Employer.cs
@@ -1,8 +1,8 @@
-using System;
-using System.Collections.Generic;
-
 namespace Microsoft.AspNet.OData
 {
+    using System;
+    using System.Collections.Generic;
+
     public class Employer
     {
         public int EmployerId { get; set; }


### PR DESCRIPTION
Just a little thing I noticed while testing. ODataActionParameters with collection parameters would cause the type in the ClassProperty to be null. This caused an exception when trying to generate the type for the parameters.

I also fixed some misplaced using directives from my previous PR.