### PR TITLE
Use clrtypeannotation to get clrtypes + underlying property field fix

### DIFF
--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -285,7 +285,7 @@
         static PropertyBuilder AddProperty( TypeBuilder addTo, Type shouldBeAdded, string name )
         {
             const MethodAttributes propertyMethodAttributes = MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
-            var field = addTo.DefineField( name, shouldBeAdded, FieldAttributes.Private );
+            var field = addTo.DefineField( "_" + name, shouldBeAdded, FieldAttributes.Private );
             var propertyBuilder = addTo.DefineProperty( name, PropertyAttributes.HasDefault, shouldBeAdded, null );
             var getter = addTo.DefineMethod( "get_" + name, propertyMethodAttributes, shouldBeAdded, Type.EmptyTypes );
             var setter = addTo.DefineMethod( "set_" + name, propertyMethodAttributes, shouldBeAdded, Type.EmptyTypes );

--- a/src/Common.OData.ApiExplorer/AspNet.OData/IModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/IModelTypeBuilder.cs
@@ -21,12 +21,13 @@
         /// <param name="structuredType">The <see cref="IEdmStructuredType">structured type</see> to evaluate.</param>
         /// <param name="clrType">The CLR <see cref="Type">type</see> mapped to the <paramref name="structuredType">structured type</paramref>.</param>
         /// <param name="apiVersion">The <see cref="ApiVersion">API version</see> associated with the type mapping.</param>
+        /// <param name="edmModel">The <see cref="IEdmModel">EdmModel</see> the structured type belongs to.</param>
         /// <returns>The original <paramref name="clrType">CLR type</paramref> or a new, dynamically generated substitute <see cref="Type">type</see>
         /// that is a subset of the original <paramref name="clrType">CLR type</paramref>, but maps one-to-one with the
         /// <paramref name="structuredType">structured type</paramref>.</returns>
         /// <remarks>If a substitution is not required, the original <paramref name="clrType">CLR type</paramref> is returned. When a substitution
         /// <see cref="Type">type</see> is generated, it is performed only once per <paramref name="apiVersion">API version</paramref>.</remarks>
-        Type NewStructuredType( IEdmStructuredType structuredType, Type clrType, ApiVersion apiVersion );
+        Type NewStructuredType( IEdmStructuredType structuredType, Type clrType, ApiVersion apiVersion, IEdmModel edmModel );
 
         /// <summary>
         /// Creates an returns a strongly-typed definition for OData action parameters.

--- a/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
@@ -290,7 +290,7 @@
                 return;
             }
 
-            var type = typeDef.GetClrType( Context.Assemblies );
+            var type = typeDef.GetClrType( Context.EdmModel );
 
             if ( quotedTypes.TryGetValue( type, out var prefix ) )
             {

--- a/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -38,8 +38,6 @@
         internal IList<ParameterDescriptor> ParameterDescriptions => ActionDescriptor.Parameters;
 #endif
 
-        internal IEnumerable<Assembly> Assemblies { get; }
-
         internal IEdmModel EdmModel { get; }
 
         internal string RouteTemplate { get; }

--- a/src/Common.OData.ApiExplorer/AspNet.OData/StructuredTypeResolver.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/StructuredTypeResolver.cs
@@ -10,15 +10,12 @@
     sealed class StructuredTypeResolver
     {
         readonly IEdmModel model;
-        readonly HashSet<Assembly> assemblies;
 
-        internal StructuredTypeResolver( IEdmModel model, IEnumerable<Assembly> assemblies )
+        internal StructuredTypeResolver( IEdmModel model )
         {
             Contract.Requires( model != null );
-            Contract.Requires( assemblies != null );
 
             this.model = model;
-            this.assemblies = new HashSet<Assembly>( assemblies );
         }
 
         internal IEdmStructuredType GetStructuredType( Type type )
@@ -26,12 +23,7 @@
             Contract.Requires( type != null );
 
             var structuredTypes = model.SchemaElements.OfType<IEdmStructuredType>();
-            var structuredType = structuredTypes.FirstOrDefault( t => type.Equals( t.GetClrType( assemblies ) ) );
-
-            if ( structuredType == null && assemblies.Add( type.Assembly ) )
-            {
-                structuredType = structuredTypes.FirstOrDefault( t => type.Equals( t.GetClrType( assemblies ) ) );
-            }
+            var structuredType = structuredTypes.FirstOrDefault( t => type.Equals( t.GetClrType( model ) ) );
 
             return structuredType;
         }

--- a/src/Common.OData.ApiExplorer/AspNet.OData/TypeExtensions.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/TypeExtensions.cs
@@ -44,7 +44,7 @@
 
             var openTypes = new Stack<Type>();
             var holder = new Lazy<Tuple<ApiVersion, StructuredTypeResolver>>(
-                () => Tuple.Create( context.ApiVersion, new StructuredTypeResolver( context.Model, context.Assemblies ) ) );
+                () => Tuple.Create( context.ApiVersion, new StructuredTypeResolver( context.Model ) ) );
 
             if ( IsSubstitutableGeneric( type, openTypes, out var innerType ) )
             {
@@ -56,7 +56,7 @@
                     return type;
                 }
 
-                var newType = context.ModelTypeBuilder.NewStructuredType( structuredType, innerType, apiVersion );
+                var newType = context.ModelTypeBuilder.NewStructuredType( structuredType, innerType, apiVersion, context.Model );
 
                 if ( innerType.Equals( newType ) )
                 {
@@ -73,7 +73,7 @@
 
                 if ( structuredType != null )
                 {
-                type = context.ModelTypeBuilder.NewStructuredType( structuredType, type, apiVersion );
+                type = context.ModelTypeBuilder.NewStructuredType( structuredType, type, apiVersion, context.Model );
                 }
             }
 

--- a/src/Common.OData.ApiExplorer/AspNet.OData/TypeSubstitutionContext.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/TypeSubstitutionContext.cs
@@ -24,17 +24,14 @@
         /// Initializes a new instance of the <see cref="TypeSubstitutionContext"/> class.
         /// </summary>
         /// <param name="model">The <see cref="IEdmModel">EDM model</see> to compare against.</param>
-        /// <param name="assemblies">The <see cref="IEnumerable{T}">sequence</see> of application <see cref="Assembly">assemblies</see>.</param>
         /// <param name="modelTypeBuilder">The associated <see cref="IModelTypeBuilder">model type builder</see>.</param>
-        public TypeSubstitutionContext( IEdmModel model, IEnumerable<Assembly> assemblies, IModelTypeBuilder modelTypeBuilder )
+        public TypeSubstitutionContext( IEdmModel model, IModelTypeBuilder modelTypeBuilder )
         {
             Arg.NotNull( model, nameof( model ) );
-            Arg.NotNull( assemblies, nameof( assemblies ) );
             Arg.NotNull( modelTypeBuilder, nameof( modelTypeBuilder ) );
 
             this.model = new Lazy<IEdmModel>( () => model );
             apiVersion = new Lazy<ApiVersion>( () => Model.GetAnnotationValue<ApiVersionAnnotation>( Model )?.ApiVersion ?? ApiVersion.Default );
-            Assemblies = assemblies;
             ModelTypeBuilder = modelTypeBuilder;
         }
 
@@ -43,17 +40,14 @@
         /// </summary>
         /// <param name="serviceProvider">The <see cref="IServiceProvider">service provider</see> that the
         /// <see cref="IEdmModel">EDM model</see> can be resolved from.</param>
-        /// <param name="assemblies">The <see cref="IEnumerable{T}">sequence</see> of application <see cref="Assembly">assemblies</see>.</param>
         /// <param name="modelTypeBuilder">The associated <see cref="IModelTypeBuilder">model type builder</see>.</param>
-        public TypeSubstitutionContext( IServiceProvider serviceProvider, IEnumerable<Assembly> assemblies, IModelTypeBuilder modelTypeBuilder )
+        public TypeSubstitutionContext( IServiceProvider serviceProvider, IModelTypeBuilder modelTypeBuilder )
         {
             Arg.NotNull( serviceProvider, nameof( serviceProvider ) );
-            Arg.NotNull( assemblies, nameof( assemblies ) );
             Arg.NotNull( modelTypeBuilder, nameof( modelTypeBuilder ) );
 
             model = new Lazy<IEdmModel>( serviceProvider.GetRequiredService<IEdmModel> );
             apiVersion = new Lazy<ApiVersion>( () => Model.GetAnnotationValue<ApiVersionAnnotation>( Model )?.ApiVersion ?? ApiVersion.Default );
-            Assemblies = assemblies;
             ModelTypeBuilder = modelTypeBuilder;
         }
 
@@ -68,12 +62,6 @@
         /// </summary>
         /// <value>The associated <see cref="ApiVersion">API version</see>.</value>
         public ApiVersion ApiVersion => apiVersion.Value;
-
-        /// <summary>
-        /// Gets the sequence of known application assemblies.
-        /// </summary>
-        /// <value>The <see cref="IEnumerable{T}">sequence</see> of application <see cref="Assembly">assemblies</see>.</value>
-        public IEnumerable<Assembly> Assemblies { get; }
 
         /// <summary>
         /// Gets the model type builder used to create substitution types.

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -37,7 +37,6 @@
             ApiVersion = apiVersion;
             serviceProvider = configuration.GetODataRootContainer( route );
             EdmModel = serviceProvider.GetRequiredService<IEdmModel>();
-            Assemblies = configuration.Services.GetAssembliesResolver().GetAssemblies();
             routeAttribute = actionDescriptor.GetCustomAttributes<ODataRouteAttribute>().FirstOrDefault();
             RouteTemplate = routeAttribute?.PathTemplate;
             Route = route;

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Web.Http.Description/ODataApiExplorer.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Web.Http.Description/ODataApiExplorer.cs
@@ -45,7 +45,7 @@
         public ODataApiExplorer( HttpConfiguration configuration, ODataApiExplorerOptions options ) : base( configuration, options )
         {
             Options = options;
-            ModelTypeBuilder = new DefaultModelTypeBuilder( configuration.Services.GetAssembliesResolver().GetAssemblies() );
+            ModelTypeBuilder = new DefaultModelTypeBuilder();
         }
 
         /// <summary>
@@ -182,7 +182,7 @@
             var serviceProvider = actionDescriptor.Configuration.GetODataRootContainer( route );
             var assembliesResolver = actionDescriptor.Configuration.Services.GetAssembliesResolver();
             var returnType = description.ResponseType ?? description.DeclaredType;
-            var context = new TypeSubstitutionContext( serviceProvider, assembliesResolver.GetAssemblies(), ModelTypeBuilder );
+            var context = new TypeSubstitutionContext( serviceProvider, ModelTypeBuilder );
 
             description.ResponseType = returnType.SubstituteIfNecessary( context );
 
@@ -271,11 +271,10 @@
             return willReadUri;
         }
 
-        ApiParameterDescription CreateParameterDescriptionFromBinding( HttpParameterBinding parameterBinding, IServiceProvider serviceProvider, IAssembliesResolver assembliesResolver )
+        ApiParameterDescription CreateParameterDescriptionFromBinding( HttpParameterBinding parameterBinding, IServiceProvider serviceProvider )
         {
             Contract.Requires( parameterBinding != null );
             Contract.Requires( serviceProvider != null );
-            Contract.Requires( assembliesResolver != null );
             Contract.Ensures( Contract.Result<ApiParameterDescription>() != null );
 
             var descriptor = parameterBinding.Descriptor;
@@ -286,7 +285,7 @@
                 description.Source = FromBody;
 
                 var parameterType = descriptor.ParameterType;
-                var context = new TypeSubstitutionContext( serviceProvider, assembliesResolver.GetAssemblies(), ModelTypeBuilder );
+                var context = new TypeSubstitutionContext( serviceProvider, ModelTypeBuilder );
                 var substitutedType = parameterType.SubstituteIfNecessary( context );
 
                 if ( parameterType != substitutedType )
@@ -318,14 +317,13 @@
             {
                 var configuration = actionDescriptor.Configuration;
                 var serviceProvider = configuration.GetODataRootContainer( route );
-                var assembliesResolver = configuration.Services.GetAssembliesResolver();
                 var parameterBindings = actionBinding.ParameterBindings;
 
                 if ( parameterBindings != null )
                 {
                     foreach ( var binding in parameterBindings )
                     {
-                        list.Add( CreateParameterDescriptionFromBinding( binding, serviceProvider, assembliesResolver ) );
+                        list.Add( CreateParameterDescriptionFromBinding( binding, serviceProvider ) );
                     }
                 }
             }

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -20,18 +20,15 @@
         internal ODataRouteBuilderContext(
             ODataRouteMapping routeMapping,
             ControllerActionDescriptor actionDescriptor,
-            IEnumerable<Assembly> assemblies,
             ODataApiExplorerOptions options )
         {
             Contract.Requires( routeMapping != null );
-            Contract.Requires( assemblies != null );
             Contract.Requires( actionDescriptor != null );
             Contract.Requires( options != null );
 
             ApiVersion = routeMapping.ApiVersion;
             serviceProvider = routeMapping.Services;
             EdmModel = serviceProvider.GetRequiredService<IEdmModel>();
-            Assemblies = assemblies;
             routeAttribute = actionDescriptor.MethodInfo.GetCustomAttributes<ODataRouteAttribute>().FirstOrDefault();
             RouteTemplate = routeAttribute?.PathTemplate;
             Route = routeMapping.Route;

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/ApiParameterContext.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/ApiParameterContext.cs
@@ -36,8 +36,6 @@
 
         internal IServiceProvider Services => RouteContext.Services;
 
-        internal IEnumerable<Assembly> Assemblies => RouteContext.Assemblies;
-
         internal IModelTypeBuilder TypeBuilder { get; }
 
         internal ODataPathTemplate PathTemplate

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/PseudoModelBindingVisitor.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNetCore.Mvc.ApiExplorer/PseudoModelBindingVisitor.cs
@@ -92,7 +92,7 @@
             }
             else
             {
-                type = type.SubstituteIfNecessary( new TypeSubstitutionContext( Context.Services, Context.Assemblies, Context.TypeBuilder ) );
+                type = type.SubstituteIfNecessary( new TypeSubstitutionContext( Context.Services, Context.TypeBuilder ) );
             }
 
             return new ApiParameterDescription()

--- a/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBindingInfoConvention.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBindingInfoConvention.cs
@@ -21,15 +21,11 @@
 
     sealed class ODataRouteBindingInfoConvention : IODataActionDescriptorConvention
     {
-        readonly IEnumerable<Assembly> assemblies;
-
-        internal ODataRouteBindingInfoConvention( IODataRouteCollectionProvider routeCollectionProvider, ApplicationPartManager partManager )
+        internal ODataRouteBindingInfoConvention( IODataRouteCollectionProvider routeCollectionProvider )
         {
             Contract.Requires( routeCollectionProvider != null );
-            Contract.Requires( partManager != null );
 
             RouteCollectionProvider = routeCollectionProvider;
-            assemblies = partManager.ApplicationParts.OfType<AssemblyPart>().Select( p => p.Assembly ).ToArray();
         }
 
         IODataRouteCollectionProvider RouteCollectionProvider { get; }
@@ -96,7 +92,7 @@
             Contract.Requires( mapping != null );
             Contract.Requires( routeInfos != null );
 
-            var routeContext = new ODataRouteBuilderContext( assemblies, mapping, action );
+            var routeContext = new ODataRouteBuilderContext( mapping, action );
             var routeBuilder = new ODataRouteBuilder( routeContext );
             var parameterContext = new ActionParameterContext( routeBuilder, routeContext );
 

--- a/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBuilderContext.Core.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBuilderContext.Core.cs
@@ -16,13 +16,11 @@
     {
         private IODataPathTemplateHandler templateHandler;
 
-        internal ODataRouteBuilderContext( IEnumerable<Assembly> assemblies, ODataRouteMapping routeMapping, ControllerActionDescriptor actionDescriptor )
+        internal ODataRouteBuilderContext( ODataRouteMapping routeMapping, ControllerActionDescriptor actionDescriptor )
         {
-            Contract.Requires( assemblies != null );
             Contract.Requires( routeMapping != null );
             Contract.Requires( actionDescriptor != null );
 
-            Assemblies = assemblies;
             ApiVersion = routeMapping.ApiVersion;
             serviceProvider = routeMapping.Services;
             EdmModel = serviceProvider.GetRequiredService<IEdmModel>();

--- a/src/Microsoft.AspNetCore.OData.Versioning/AspNetCore.Mvc/ODataActionDescriptorProvider.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning/AspNetCore.Mvc/ODataActionDescriptorProvider.cs
@@ -38,7 +38,7 @@
             var conventions = new IODataActionDescriptorConvention[]
             {
                 new ImplicitHttpMethodConvention(),
-                new ODataRouteBindingInfoConvention( routeCollectionProvider, partManager ),
+                new ODataRouteBindingInfoConvention( routeCollectionProvider ),
             };
 
             foreach ( var action in ODataActions( results ) )

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
@@ -398,8 +398,7 @@
 
         static TypeSubstitutionContext NewContext( IEdmModel model )
         {
-            var assemblies = new[] { typeof( DefaultModelTypeBuilderTest ).Assembly };
-            return new TypeSubstitutionContext( model, assemblies, new DefaultModelTypeBuilder( assemblies ) );
+            return new TypeSubstitutionContext( model, new DefaultModelTypeBuilder() );
         }
     }
 }

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
@@ -398,8 +398,7 @@
 
         static TypeSubstitutionContext NewContext( IEdmModel model )
         {
-            var assemblies = new[] { typeof( DefaultModelTypeBuilderTest ).Assembly };
-            return new TypeSubstitutionContext( model, assemblies, new DefaultModelTypeBuilder( assemblies ) );
+            return new TypeSubstitutionContext( model, new DefaultModelTypeBuilder() );
         }
     }
 }


### PR DESCRIPTION
Instead of iterating through assemblies use the ClrTypeAnnotation from Microsoft.AspNet.OData to get clr types.

All IEdmSchemaTypes should be decorated with this property so this should prevent iteration over assemblies to find the corresponding clr type. This makes performance a lot better, it only takes around 10 seconds to generate the api description now.

Changed a lot of methods that were passing around the assemblies for only this, I think I removed all unused lists of assemblies.

Also includes a minor fix needed for deserialization of substituted types. The underlying property field had the exact same name as the property name which caused some issues when trying to generate JSON.