### PR TITLE
Fixed type builder not keeping track of clrtypes that match the edm

### DIFF
--- a/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/DefaultModelTypeBuilder.cs
@@ -132,7 +132,7 @@
 
             if ( clrTypeMatchesEdmType )
             {
-                return clrType;
+                return generatedEdmTypes.GetOrAdd( typeKey, clrType.GetTypeInfo() );
             }
 
             var signature = new ClassSignature( clrType, properties, apiVersion );

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.0.1</VersionPrefix>
+  <VersionPrefix>3.0.2</VersionPrefix>
   <AssemblyVersion>3.0.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Web API Versioned API Explorer for OData v4.0</AssemblyTitle>

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/ReleaseNotes.txt
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/ReleaseNotes.txt
@@ -1,2 +1,1 @@
-﻿Fixed query options for non-action POST
-Fix tracking CLR types that match the EDM (#425)
+﻿Fix tracking CLR types that match the EDM (#425)

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/ReleaseNotes.txt
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,2 @@
 ﻿Fixed query options for non-action POST
+Fix tracking CLR types that match the EDM (#425)

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.1.0</VersionPrefix>
+  <VersionPrefix>3.1.1</VersionPrefix>
   <AssemblyVersion>3.1.0.0</AssemblyVersion>
   <TargetFramework>netstandard2.0</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Core Versioned API Explorer for OData v4.0</AssemblyTitle>

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/ReleaseNotes.txt
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/ReleaseNotes.txt
@@ -1,2 +1,1 @@
-﻿Fixed query options for non-action POST
-Fix tracking CLR types that match the EDM (#425)
+﻿Fix tracking CLR types that match the EDM (#425)

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/ReleaseNotes.txt
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/ReleaseNotes.txt
@@ -1,1 +1,2 @@
 ﻿Fixed query options for non-action POST
+Fix tracking CLR types that match the EDM (#425)

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
@@ -8,6 +8,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Reflection.Emit;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
 
@@ -375,6 +376,29 @@
 
             Assert.Equal( "Manager", attributeWithParams.AllowedRoles[0] );
             Assert.Equal( "Employer", attributeWithParams.AllowedRoles[1] );
+        }
+
+        [Fact]
+        public void substitute_should_resolve_types_that_reference_a_model_that_match_the_edm()
+        {
+            // arrange
+            var modelBuilder = new ODataConventionModelBuilder();
+
+            var shipment = modelBuilder.EntitySet<Shipment>( "Shipments" ).EntityType;
+            shipment.Ignore( s => s.ShippedOn );
+            var originalType = typeof(Shipment);
+
+            modelBuilder.EntitySet<Address>("Addresses");
+            var addressType = typeof(Address);
+
+            var context = NewContext( modelBuilder.GetEdmModel() );
+
+            // act
+            addressType.SubstituteIfNecessary( context );
+            var substitutionType = originalType.SubstituteIfNecessary( context );
+
+            // assert
+            Assert.False( substitutionType is TypeBuilder );
         }
 
         public static IEnumerable<object[]> SubstitutionNotRequiredData

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/DefaultModelTypeBuilderTest.cs
@@ -252,7 +252,7 @@
             // arrange
             var modelBuilder = new ODataConventionModelBuilder();
             var contact = modelBuilder.EntitySet<Contact>( "Contacts" ).EntityType;
-            contact.Ignore( c => c.Email  );
+            contact.Ignore( c => c.Email );
             var action = contact.Action( "PlanInterview" );
 
             action.Parameter<DateTime>( "when" );
@@ -315,7 +315,7 @@
         [Fact]
         public void substitute_should_generate_types_for_actions_with_the_same_name_in_different_controllers()
         {
-            // arrange 
+            // arrange
             var modelBuilder = new ODataConventionModelBuilder();
             var contact = modelBuilder.EntitySet<Contact>( "Contacts" ).EntityType;
             var action = contact.Action( "PlanMeeting" );
@@ -330,7 +330,7 @@
             action.Parameter<DateTime>( "when" );
             action.CollectionParameter<Employee>( "attendees" );
             action.Parameter<string>( "project" );
-            
+
             var context = NewContext( modelBuilder.GetEdmModel() );
             var model = context.Model;
 
@@ -338,7 +338,7 @@
             var operations = model.FindDeclaredOperations( qualifiedName ).Select( o => (IEdmAction) o ).ToArray();
             var services = new ServiceCollection();
             services.AddSingleton( model );
-            
+
             // act
             var contactActionType = context.ModelTypeBuilder.NewActionParameters( services.BuildServiceProvider(), operations[0], ApiVersion.Default, contact.Name );
             var employeesActionType = context.ModelTypeBuilder.NewActionParameters( services.BuildServiceProvider(), operations[1], ApiVersion.Default, employee.Name );
@@ -364,7 +364,7 @@
             var employee = modelBuilder.EntitySet<Employee>( "Employees" ).EntityType;
             employee.Ignore( e => e.FirstName );
             var originalType = typeof( Employee );
-            
+
             var context = NewContext( modelBuilder.GetEdmModel() );
 
             // act
@@ -386,10 +386,10 @@
 
             var shipment = modelBuilder.EntitySet<Shipment>( "Shipments" ).EntityType;
             shipment.Ignore( s => s.ShippedOn );
-            var originalType = typeof(Shipment);
+            var originalType = typeof( Shipment );
 
-            modelBuilder.EntitySet<Address>("Addresses");
-            var addressType = typeof(Address);
+            modelBuilder.EntitySet<Address>( "Addresses" );
+            var addressType = typeof( Address );
 
             var context = NewContext( modelBuilder.GetEdmModel() );
 

--- a/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Shipment.cs
+++ b/test/Microsoft.AspNet.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Shipment.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.AspNet.OData
+{
+    using System;
+
+    public class Shipment
+    {
+        public int Id { get; set; }
+        
+        public DateTime ShippedOn { get; set; }
+        
+        public double Weight { get; set; }
+        
+        public Address Destination { get; set; }
+    }
+}

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Shipment.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNet.OData/Shipment.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.AspNet.OData
+{
+    using System;
+
+    public class Shipment
+    {
+        public int Id { get; set; }
+        
+        public DateTime ShippedOn { get; set; }
+        
+        public double Weight { get; set; }
+        
+        public Address Destination { get; set; }
+    }
+}


### PR DESCRIPTION
This is was a small oversight where types that have properties referencing other types that matched the edm would never resolve their property. This caused the type to never be resolved and throw an exception when being explored.