### PR TITLE
Add IsDeprecated Extension Method

### DIFF
--- a/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/System.Web.Http/Description/ApiDescriptionExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/System.Web.Http/Description/ApiDescriptionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace System.Web.Http.Description
 {
     using Microsoft;
+    using Microsoft.Web.Http;
     using Microsoft.Web.Http.Description;
     using System.Diagnostics.Contracts;
     using System.Linq;
@@ -11,6 +12,44 @@
     /// </summary>
     public static class ApiDescriptionExtensions
     {
+        /// <summary>
+        /// Gets the API version associated with the API description.
+        /// </summary>
+        /// <param name="apiDescription">The <see cref="ApiDescription">API description</see> to get the API version for.</param>
+        /// <returns>The associated <see cref="ApiVersion">API version</see> or <c>null</c>.</returns>
+        /// <remarks>This method always returns <c>null</c> unless the <paramref name="apiDescription">API description</paramref>
+        /// is of type <see cref="VersionedApiDescription"/>.</remarks>
+        public static ApiVersion GetApiVersion( this ApiDescription apiDescription )
+        {
+            Arg.NotNull( apiDescription, nameof( apiDescription ) );
+
+            if ( apiDescription is VersionedApiDescription versionedApiDescription )
+            {
+                return versionedApiDescription.ApiVersion;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the associated API description is deprecated.
+        /// </summary>
+        /// <param name="apiDescription">The <see cref="ApiDescription">API description</see> to evaluate.</param>
+        /// <returns><c>True</c> if the <see cref="ApiDescription">API description</see> is deprecated; otherwise, <c>false</c>.</returns>
+        /// <remarks>This method always returns <c>false</c> unless the <paramref name="apiDescription">API description</paramref>
+        /// is of type <see cref="VersionedApiDescription"/>.</remarks>
+        public static bool IsDeprecated( this ApiDescription apiDescription )
+        {
+            Arg.NotNull( apiDescription, nameof( apiDescription ) );
+
+            if ( apiDescription is VersionedApiDescription versionedApiDescription )
+            {
+                return versionedApiDescription.IsDeprecated;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Gets the group name associated with the API description.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/ApiDescriptionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/ApiDescriptionExtensions.cs
@@ -1,10 +1,12 @@
 ﻿namespace Microsoft.AspNetCore.Mvc.ApiExplorer
 {
+    using Microsoft.AspNetCore.Mvc.Abstractions;
     using System;
     using System.ComponentModel;
     using System.Diagnostics.Contracts;
     using System.Linq;
     using static Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource;
+    using static Microsoft.AspNetCore.Mvc.Versioning.ApiVersionMapping;
     using static System.ComponentModel.EditorBrowsableState;
     using static System.Globalization.CultureInfo;
     using static System.Linq.Enumerable;
@@ -21,6 +23,21 @@
         /// <param name="apiDescription">The <see cref="ApiDescription">API description</see> to get the API version for.</param>
         /// <returns>The associated <see cref="ApiVersion">API version</see> or <c>null</c>.</returns>
         public static ApiVersion GetApiVersion( this ApiDescription apiDescription ) => apiDescription.GetProperty<ApiVersion>();
+
+        /// <summary>
+        /// Gets a value indicating whether the associated API description is deprecated.
+        /// </summary>
+        /// <param name="apiDescription">The <see cref="ApiDescription">API description</see> to evaluate.</param>
+        /// <returns><c>True</c> if the <see cref="ApiDescription">API description</see> is deprecated; otherwise, <c>false</c>.</returns>
+        public static bool IsDeprecated( this ApiDescription apiDescription )
+        {
+            Arg.NotNull( apiDescription, nameof( apiDescription ) );
+
+            var apiVersion = apiDescription.GetApiVersion();
+            var model = apiDescription.ActionDescriptor.GetApiVersionModel( Explicit | Implicit );
+
+            return model.DeprecatedApiVersions.Contains( apiVersion );
+        }
 
         /// <summary>
         /// Sets the API version associated with the API description.

--- a/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/System.Web.Http/Description/ApiDescriptionExtensionsTest.cs
+++ b/test/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.Tests/System.Web.Http/Description/ApiDescriptionExtensionsTest.cs
@@ -1,0 +1,89 @@
+﻿namespace System.Web.Http.Description
+{
+    using FluentAssertions;
+    using Microsoft.Web.Http;
+    using Microsoft.Web.Http.Description;
+    using Xunit;
+
+    public class ApiDescriptionExtensionsTest
+    {
+        [Fact]
+        public void get_api_version_should_return_null_by_default()
+        {
+            // arrange
+            var description = new ApiDescription();
+
+            // act
+            var apiVersion = description.GetApiVersion();
+
+            // assert
+            apiVersion.Should().BeNull();
+        }
+
+        [Fact]
+        public void get_api_version_should_return_property_value()
+        {
+            // arrange
+            var apiVersion = new ApiVersion( 1, 0 );
+            var description = new VersionedApiDescription() { ApiVersion = apiVersion };
+
+            // act
+            var result = description.GetApiVersion();
+
+            // assert
+            result.Should().Be( apiVersion );
+        }
+
+        [Fact]
+        public void is_deprecated_should_return_false_by_default()
+        {
+            // arrange
+            var description = new ApiDescription();
+
+            // act
+            var deprecated = description.IsDeprecated();
+
+            // assert
+            deprecated.Should().BeFalse();
+        }
+
+        [Fact]
+        public void is_deprecated_should_return_property_value()
+        {
+            // arrange
+            var description = new VersionedApiDescription() { IsDeprecated = true };
+
+            // act
+            var deprecated = description.IsDeprecated();
+
+            // assert
+            deprecated.Should().BeTrue();
+        }
+
+        [Fact]
+        public void get_group_name_should_return_null_by_default()
+        {
+            // arrange
+            var description = new ApiDescription();
+
+            // act
+            var groupName = description.GetGroupName();
+
+            // assert
+            groupName.Should().BeNull();
+        }
+
+        [Fact]
+        public void get_group_name_should_return_property_value()
+        {
+            // arrange
+            var description = new VersionedApiDescription() { GroupName = "v1" };
+
+            // act
+            var groupName = description.GetGroupName();
+
+            // assert
+            groupName.Should().Be( "v1" );
+        }
+    }
+}


### PR DESCRIPTION
Add an extension method for determining whether an ApiDescription is deprecated. Related to #441.

NOTE: This is possible to do today, but you have to know how to do it. This extension method simplifies the requirement for developers.