### PR TITLE
fallback to a sane default when edm parameters and clr parameters disagree

### DIFF
--- a/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilder.cs
@@ -222,12 +222,14 @@
                 var actionParameters = Context.ParameterDescriptions.ToDictionary( p => p.Name, StringComparer.OrdinalIgnoreCase );
                 var parameter = parameters.Current;
                 var name = parameter.Name;
+                actionParameters.TryGetValue( name, out var mappedParameter );
 #if WEBAPI
-                var routeParameterName = actionParameters[name].ParameterDescriptor.ParameterName;
+                var routeParameterName = mappedParameter?.ParameterDescriptor?.ParameterName ?? name;
 #elif API_EXPLORER
-                var routeParameterName = actionParameters[name].ParameterDescriptor.Name;
+
+                var routeParameterName = mappedParameter?.ParameterDescriptor?.Name ?? name;
 #else
-                var routeParameterName = actionParameters[name].Name;
+                var routeParameterName = mappedParameter?.Name ?? name;
 #endif
 
                 builder.Append( '(' );
@@ -239,12 +241,14 @@
                 {
                     parameter = parameters.Current;
                     name = parameter.Name;
+                    actionParameters.TryGetValue( name, out mappedParameter );
 #if WEBAPI
-                    routeParameterName = actionParameters[name].ParameterDescriptor.ParameterName;
+                    routeParameterName = mappedParameter?.ParameterDescriptor?.ParameterName ?? name;
 #elif API_EXPLORER
-                    routeParameterName = actionParameters[name].ParameterDescriptor.Name;
+
+                    routeParameterName = mappedParameter?.ParameterDescriptor?.Name ?? name;
 #else
-                    routeParameterName = actionParameters[name].Name;
+                    routeParameterName = mappedParameter?.Name ?? name;
 #endif
                     builder.Append( ',' );
                     builder.Append( name );


### PR DESCRIPTION
I have a custom odata routing convention to deal with optional parameters, unfortunately this leaves me in a position where the clr parameters disagree with the declared edm parameters. The routing convention will dispatch and translate where appropriate but attempting to build the swagger doc fails as a result. I have an additional PR that i will be sending to the odata\odata.net repo, The odata path templates produced in this workflow end up having a slightly different shape that just needed to be handled.