### PR TITLE
Return API Version in Media Type

### DIFF
--- a/src/Common/Common.projitems
+++ b/src/Common/Common.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionParameterSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionReader.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionReaderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IApiVersionSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IErrorResponseProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Versioning\IReportApiVersions.cs" />

--- a/src/Common/Versioning/IApiVersionReaderExtensions.cs
+++ b/src/Common/Versioning/IApiVersionReaderExtensions.cs
@@ -1,0 +1,41 @@
+﻿#if WEBAPI
+namespace Microsoft.Web.Http.Versioning
+#else
+namespace Microsoft.AspNetCore.Mvc.Versioning
+#endif
+{
+    using System;
+    using static ApiVersionParameterLocation;
+
+    internal static class IApiVersionReaderExtensions
+    {
+        internal static bool VersionsByMediaType( this IApiVersionReader reader )
+        {
+            var context = new DescriptionContext();
+            reader.AddParameters( context );
+            return context.HasMediaTypeApiVersion;
+        }
+
+        internal static string GetMediaTypeVersionParameter( this IApiVersionReader reader )
+        {
+            var context = new DescriptionContext();
+            reader.AddParameters( context );
+            return context.ParameterName;
+        }
+
+        sealed class DescriptionContext : IApiVersionParameterDescriptionContext
+        {
+            internal string ParameterName { get; private set; }
+
+            internal bool HasMediaTypeApiVersion { get; private set; }
+
+            public void AddParameter( string name, ApiVersionParameterLocation location )
+            {
+                if ( HasMediaTypeApiVersion |= location == MediaTypeParameter )
+                {
+                    ParameterName = name;
+                }
+            }
+        }
+    }
+}

--- a/src/Common/Versioning/MediaTypeApiVersionReader.cs
+++ b/src/Common/Versioning/MediaTypeApiVersionReader.cs
@@ -27,12 +27,12 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
     /// </summary>
     public partial class MediaTypeApiVersionReader : IApiVersionReader
     {
-        string parameterName = "v";
+        string parameterName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaTypeApiVersionReader"/> class.
         /// </summary>
-        public MediaTypeApiVersionReader() { }
+        public MediaTypeApiVersionReader() => parameterName = "v";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaTypeApiVersionReader"/> class.

--- a/src/Microsoft.AspNet.WebApi.Versioning/Microsoft.AspNet.WebApi.Versioning.csproj
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Microsoft.AspNet.WebApi.Versioning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.0.1</VersionPrefix>
+  <VersionPrefix>3.0.2</VersionPrefix>
   <AssemblyVersion>3.0.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Web API Versioning</AssemblyTitle>

--- a/src/Microsoft.AspNet.WebApi.Versioning/ReleaseNotes.txt
+++ b/src/Microsoft.AspNet.WebApi.Versioning/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix non-OWIN route enumeration (#428)
+﻿Add API version parameter to Content-Type (#484)

--- a/src/Microsoft.AspNet.WebApi.Versioning/System.Web.Http/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/System.Web.Http/HttpConfigurationExtensions.cs
@@ -57,6 +57,11 @@
                 configuration.Filters.Add( new ReportApiVersionsAttribute() );
             }
 
+            if ( options.ApiVersionReader.VersionsByMediaType() )
+            {
+                configuration.Filters.Add( new ApplyContentTypeVersionActionFilter( options.ApiVersionReader ) );
+            }
+
             configuration.Properties.AddOrUpdate( ApiVersioningOptionsKey, options, ( key, oldValue ) => options );
             configuration.ParameterBindingRules.Add( typeof( ApiVersion ), ApiVersionParameterBinding.Create );
         }

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/ApplyContentTypeVersionActionFilter.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/ApplyContentTypeVersionActionFilter.cs
@@ -1,0 +1,64 @@
+﻿namespace Microsoft.Web.Http.Versioning
+{
+    using System;
+    using System.Net.Http.Headers;
+    using System.Web.Http;
+    using System.Web.Http.Filters;
+
+    sealed class ApplyContentTypeVersionActionFilter : ActionFilterAttribute
+    {
+        readonly string parameterName;
+
+        public ApplyContentTypeVersionActionFilter( IApiVersionReader reader ) =>
+            parameterName = reader.GetMediaTypeVersionParameter();
+
+        public override bool AllowMultiple => false;
+
+        public override void OnActionExecuted( HttpActionExecutedContext actionExecutedContext )
+        {
+            var response = actionExecutedContext.Response;
+
+            if ( response == null )
+            {
+                return;
+            }
+
+            var headers = response.Content?.Headers;
+            var contentType = headers?.ContentType;
+
+            if ( contentType == null )
+            {
+                return;
+            }
+
+            var apiVersion = actionExecutedContext.Request.GetRequestedApiVersion();
+
+            if ( apiVersion == null )
+            {
+                return;
+            }
+
+            var parameters = contentType.Parameters;
+            var versionParameter = default( NameValueHeaderValue );
+            var comparer = StringComparer.OrdinalIgnoreCase;
+
+            foreach ( var parameter in parameters )
+            {
+                if ( comparer.Equals( parameter.Name, parameterName ) )
+                {
+                    versionParameter = parameter;
+                    break;
+                }
+            }
+
+            if ( versionParameter == null )
+            {
+                versionParameter = new NameValueHeaderValue( parameterName );
+                parameters.Add( versionParameter );
+            }
+
+            versionParameter.Value = apiVersion.ToString();
+            headers.ContentType = contentType;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.AspNetCore.Mvc.Versioning.csproj
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.AspNetCore.Mvc.Versioning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.1.2</VersionPrefix>
+  <VersionPrefix>3.1.3</VersionPrefix>
   <AssemblyVersion>3.1.0.0</AssemblyVersion>
   <TargetFramework>netstandard2.0</TargetFramework>
   <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.Extensions.DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Microsoft.Extensions.DependencyInjection/IServiceCollectionExtensions.cs
@@ -62,6 +62,7 @@
             services.TryAddSingleton<IApiVersionRoutePolicy, DefaultApiVersionRoutePolicy>();
             services.TryAddSingleton<IApiControllerFilter, DefaultApiControllerFilter>();
             services.TryAddSingleton<ReportApiVersionsAttribute>();
+            services.AddSingleton<ApplyContentTypeVersionActionFilter>();
             services.TryAddSingleton( OnRequestIReportApiVersions );
             services.TryAddEnumerable( Transient<IPostConfigureOptions<MvcOptions>, ApiVersioningMvcOptionsSetup>() );
             services.TryAddEnumerable( Transient<IPostConfigureOptions<RouteOptions>, ApiVersioningRouteOptionsSetup>() );

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/ReleaseNotes.txt
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Fix ApiVersion model binding (#452)
+﻿Add API version parameter to Content-Type (#484)

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/ReportApiVersionsAttribute.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/ReportApiVersionsAttribute.cs
@@ -1,9 +1,12 @@
 ﻿namespace Microsoft.AspNetCore.Mvc
 {
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc.Abstractions;
     using Microsoft.AspNetCore.Mvc.Filters;
     using Microsoft.AspNetCore.Mvc.Versioning;
     using System;
+    using System.Threading.Tasks;
+    using static System.Threading.Tasks.Task;
 
     /// <content>
     /// Provides additional implementation specific to ASP.NET Core.
@@ -49,8 +52,15 @@
 
             if ( !model.IsApiVersionNeutral )
             {
-                reporter.Report( response.Headers, model );
+                response.OnStarting( ReportApiVersions, (response.Headers, model) );
             }
+        }
+
+        Task ReportApiVersions( object state )
+        {
+            var (headers, model) = ((IHeaderDictionary, ApiVersionModel)) state;
+            reporter.Report( headers, model );
+            return CompletedTask;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersioningMvcOptionsSetup.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApiVersioningMvcOptionsSetup.cs
@@ -29,6 +29,11 @@
                 options.Filters.AddService<ReportApiVersionsAttribute>();
             }
 
+            if ( value.ApiVersionReader.VersionsByMediaType() )
+            {
+                options.Filters.AddService<ApplyContentTypeVersionActionFilter>();
+            }
+
             var modelMetadataDetailsProviders = options.ModelMetadataDetailsProviders;
 
             modelMetadataDetailsProviders.Insert( 0, new SuppressChildValidationMetadataProvider( typeof( ApiVersion ) ) );

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApplyContentTypeVersionActionFilter.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/ApplyContentTypeVersionActionFilter.cs
@@ -1,0 +1,74 @@
+﻿namespace Microsoft.AspNetCore.Mvc.Versioning
+{
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.Extensions.Primitives;
+    using Microsoft.Net.Http.Headers;
+    using System.Threading.Tasks;
+    using static System.StringComparison;
+    using static System.Threading.Tasks.Task;
+
+    sealed class ApplyContentTypeVersionActionFilter : IActionFilter
+    {
+        readonly string parameterName;
+
+        public ApplyContentTypeVersionActionFilter( IApiVersionReader reader ) =>
+            parameterName = reader.GetMediaTypeVersionParameter();
+
+        public void OnActionExecuted( ActionExecutedContext context ) { }
+
+        public void OnActionExecuting( ActionExecutingContext context )
+        {
+            var httpContext = context.HttpContext;
+            var response = httpContext.Response;
+
+            if ( response == null )
+            {
+                return;
+            }
+
+            response.OnStarting( ApplyApiVersionMediaTypeParameter, httpContext );
+        }
+
+        Task ApplyApiVersionMediaTypeParameter( object state )
+        {
+            var context = (HttpContext) state;
+            var headers = context.Response.GetTypedHeaders();
+            var contentType = headers.ContentType;
+
+            if ( contentType == null )
+            {
+                return CompletedTask;
+            }
+
+            var apiVersion = context.GetRequestedApiVersion();
+
+            if ( apiVersion == null )
+            {
+                return CompletedTask;
+            }
+
+            var parameters = contentType.Parameters;
+            var parameter = default( NameValueHeaderValue );
+
+            for ( var i = 0; i < parameters.Count; i++ )
+            {
+                if ( parameters[i].Name.Equals( parameterName, OrdinalIgnoreCase ) )
+                {
+                    parameter = parameters[i];
+                    break;
+                }
+            }
+
+            if ( parameter == null )
+            {
+                parameter = new NameValueHeaderValue( parameterName );
+                parameters.Add( parameter );
+            }
+
+            parameter.Value = new StringSegment( apiVersion.ToString() );
+            headers.ContentType = contentType;
+            return CompletedTask;
+        }
+    }
+}

--- a/test/Microsoft.AspNet.WebApi.Acceptance.Tests/Http/MediaTypeNegotiation/given a versioned ApiController/when using media type negotiation.cs
+++ b/test/Microsoft.AspNet.WebApi.Acceptance.Tests/Http/MediaTypeNegotiation/given a versioned ApiController/when using media type negotiation.cs
@@ -28,10 +28,12 @@
 
             // act
             var response = await GetAsync( "api/values" ).EnsureSuccessStatusCode();
-            var content = await response.Content.ReadAsExampleAsync( example );
+            var body = response.Content;
+            var content = await body.ReadAsExampleAsync( example );
 
             // assert
             response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0" );
+            body.Headers.ContentType.Parameters.Single( p => p.Name == "v" ).Value.Should().Be( apiVersion );
             content.Should().BeEquivalentTo( new { controller, version = apiVersion } );
         }
 
@@ -61,9 +63,11 @@
 
             // act
             var response = await GetAsync( requestUrl ).EnsureSuccessStatusCode();
-            var content = await response.Content.ReadAsExampleAsync( example );
+            var body = response.Content;
+            var content = await body.ReadAsExampleAsync( example );
 
             // assert
+            body.Headers.ContentType.Parameters.Single( p => p.Name == "v" ).Value.Should().Be( apiVersion );
             content.Should().BeEquivalentTo( new { controller, version = apiVersion } );
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Mvc/MediaTypeNegotiation/given a versioned Controller/when using media type negotiation.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Acceptance.Tests/Mvc/MediaTypeNegotiation/given a versioned Controller/when using media type negotiation.cs
@@ -28,12 +28,13 @@
 
             // act
             var response = await GetAsync( "api/values" ).EnsureSuccessStatusCode();
-            var content = await response.Content.ReadAsExampleAsync( example );
+            var body = response.Content;
+            var content = await body.ReadAsExampleAsync( example );
 
             // assert
             response.Headers.GetValues( "api-supported-versions" ).Single().Should().Be( "1.0, 2.0" );
+            body.Headers.ContentType.Parameters.Single( p => p.Name == "v" ).Value.Should().Be( apiVersion );
             content.Should().BeEquivalentTo( new { controller, version = apiVersion } );
-
         }
 
         [Fact]
@@ -64,9 +65,11 @@
 
             // act
             var response = await GetAsync( requestUrl ).EnsureSuccessStatusCode();
-            var content = await response.Content.ReadAsExampleAsync( example );
+            var body = response.Content;
+            var content = await body.ReadAsExampleAsync( example );
 
             // assert
+            body.Headers.ContentType.Parameters.Single( p => p.Name == "v" ).Value.Should().Be( apiVersion );
             content.Should().BeEquivalentTo( new { controller, version = apiVersion } );
         }
 

--- a/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/ReportApiVersionsAttributeTest.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Versioning.Tests/ReportApiVersionsAttributeTest.cs
@@ -1,68 +1,89 @@
 ﻿namespace Microsoft.AspNetCore.Mvc
 {
-    using Abstractions;
-    using AspNetCore.Routing;
-    using Filters;
     using FluentAssertions;
-    using Http;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.AspNetCore.Mvc.Versioning;
+    using Microsoft.AspNetCore.Routing;
     using Moq;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Versioning;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class ReportApiVersionsAttributeTest
     {
-        static ActionExecutingContext CreateContext( ApiVersionModel model )
-        {
-            var headers = new HeaderDictionary();
-            var response = new Mock<HttpResponse>();
-            var httpContext = new Mock<HttpContext>();
-            var action = new ActionDescriptor();
-            var actionContext = new ActionContext( httpContext.Object, new RouteData(), action  );
-            var filters = new IFilterMetadata[0];
-            var actionArguments = new Dictionary<string, object>();
-            var controller = default( object );
-
-            response.SetupGet( r => r.Headers ).Returns( headers );
-            httpContext.SetupGet( c => c.Response ).Returns( response.Object );
-            action.SetProperty( model );
-
-            return new ActionExecutingContext( actionContext, filters, actionArguments, controller );
-        }
-
         [Fact]
-        public void on_action_executing_should_add_version_headers()
+        public async Task on_action_executing_should_add_version_headers()
         {
             // arrange
             var supported = new[] { new ApiVersion( 1, 0 ), new ApiVersion( 2, 0 ) };
             var deprecated = new[] { new ApiVersion( 0, 5 ) };
             var model = new ApiVersionModel( supported, deprecated );
-            var context = CreateContext( model );
+            var onStartResponse = new List<(Func<object, Task>, object)>();
+            var context = CreateContext( model, onStartResponse );
             var attribute = new ReportApiVersionsAttribute();
 
             // act
             attribute.OnActionExecuting( context );
 
+            for ( var i = 0; i < onStartResponse.Count; i++ )
+            {
+                var (callback, state) = onStartResponse[i];
+                await callback( state );
+            }
+
             // assert
-            context.HttpContext.Response.Headers["api-supported-versions"].Single().Should().Be( "1.0, 2.0" );
-            context.HttpContext.Response.Headers["api-deprecated-versions"].Single().Should().Be( "0.5" );
+            var headers = context.HttpContext.Response.Headers;
+
+            headers["api-supported-versions"].Single().Should().Be( "1.0, 2.0" );
+            headers["api-deprecated-versions"].Single().Should().Be( "0.5" );
         }
 
         [Fact]
-        public void on_action_executing_should_not_add_headers_for_versionX2Dneutral_controller()
+        public async Task on_action_executing_should_not_add_headers_for_versionX2Dneutral_controller()
         {
             // arrange
-            var context = CreateContext( ApiVersionModel.Neutral );
+            var onStartResponse = new List<(Func<object, Task>, object)>();
+            var context = CreateContext( ApiVersionModel.Neutral, onStartResponse );
             var attribute = new ReportApiVersionsAttribute();
 
             // act
             attribute.OnActionExecuting( context );
 
+            for ( var i = 0; i < onStartResponse.Count; i++ )
+            {
+                var (callback, state) = onStartResponse[i];
+                await callback( state );
+            }
 
             // assert
-            context.HttpContext.Response.Headers.ContainsKey( "api-supported-versions" ).Should().BeFalse();
-            context.HttpContext.Response.Headers.ContainsKey( "api-deprecated-versions" ).Should().BeFalse();
+            var headers = context.HttpContext.Response.Headers;
+
+            headers.ContainsKey( "api-supported-versions" ).Should().BeFalse();
+            headers.ContainsKey( "api-deprecated-versions" ).Should().BeFalse();
+        }
+
+        static ActionExecutingContext CreateContext( ApiVersionModel model, ICollection<(Func<object, Task>, object)> onStartResponse )
+        {
+            var headers = new HeaderDictionary();
+            var response = new Mock<HttpResponse>();
+            var httpContext = new Mock<HttpContext>();
+            var action = new ActionDescriptor();
+            var actionContext = new ActionContext( httpContext.Object, new RouteData(), action );
+            var filters = Array.Empty<IFilterMetadata>();
+            var actionArguments = new Dictionary<string, object>();
+            var controller = default( object );
+
+            response.SetupGet( r => r.Headers ).Returns( headers );
+            response.Setup( r => r.OnStarting( It.IsAny<Func<object, Task>>(), It.IsAny<object>() ) )
+                    .Callback( ( Func<object, Task> callback, object state ) => onStartResponse.Add( (callback, state) ) );
+            httpContext.SetupGet( c => c.Response ).Returns( response.Object );
+            action.SetProperty( model );
+
+            return new ActionExecutingContext( actionContext, filters, actionArguments, controller );
         }
     }
 }


### PR DESCRIPTION
Adds support to return the API version in the **Content-Type** HTTP header when versioning by media type. Also contains a minor optimization when writing API Versioning response headers.