### PR TITLE
OData Fixes 2019-08-07

### DIFF
--- a/samples/aspnetcore/ODataBasicSample/Startup.cs
+++ b/samples/aspnetcore/ODataBasicSample/Startup.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.Examples
 {
+    using Microsoft.AspNet.OData;
     using Microsoft.AspNet.OData.Builder;
     using Microsoft.AspNet.OData.Extensions;
     using Microsoft.AspNetCore.Builder;
@@ -7,6 +8,7 @@
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using static Microsoft.AspNetCore.Mvc.CompatibilityVersion;
+    using static Microsoft.OData.ODataUrlKeyDelimiter;
 
     public class Startup
     {
@@ -39,6 +41,11 @@
                 routeBuilder =>
                 {
                     var models = modelBuilder.GetEdmModels();
+
+                    // the following will not work as expected
+                    // BUG: https://github.com/OData/WebApi/issues/1837
+                    // routeBuilder.SetDefaultODataOptions( new ODataOptions() { UrlKeyDelimiter = Parentheses } );
+                    routeBuilder.ServiceProvider.GetRequiredService<ODataOptions>().UrlKeyDelimiter = Parentheses;
                     routeBuilder.MapVersionedODataRoutes( "odata", "api", models );
                     routeBuilder.MapVersionedODataRoutes( "odata-bypath", "v{version:apiVersion}", models );
                 } );

--- a/samples/aspnetcore/SwaggerODataSample/Startup.cs
+++ b/samples/aspnetcore/SwaggerODataSample/Startup.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.Examples
 {
+    using Microsoft.AspNet.OData;
     using Microsoft.AspNet.OData.Builder;
     using Microsoft.AspNet.OData.Extensions;
     using Microsoft.AspNetCore.Builder;
@@ -13,6 +14,7 @@
     using System.Reflection;
     using static Microsoft.AspNet.OData.Query.AllowedQueryOptions;
     using static Microsoft.AspNetCore.Mvc.CompatibilityVersion;
+    using static Microsoft.OData.ODataUrlKeyDelimiter;
 
     /// <summary>
     /// Represents the startup process for the application.
@@ -75,7 +77,15 @@
         /// <param name="provider">The API version descriptor provider used to enumerate defined API versions.</param>
         public void Configure( IApplicationBuilder app, IHostingEnvironment env, VersionedODataModelBuilder modelBuilder, IApiVersionDescriptionProvider provider )
         {
-            app.UseMvc( routeBuilder => routeBuilder.MapVersionedODataRoutes( "odata", "api", modelBuilder.GetEdmModels() ) );
+            app.UseMvc(
+                routeBuilder =>
+                {
+                    // the following will not work as expected
+                    // BUG: https://github.com/OData/WebApi/issues/1837
+                    // routeBuilder.SetDefaultODataOptions( new ODataOptions() { UrlKeyDelimiter = Parentheses } );
+                    routeBuilder.ServiceProvider.GetRequiredService<ODataOptions>().UrlKeyDelimiter = Parentheses;
+                    routeBuilder.MapVersionedODataRoutes( "odata", "api", modelBuilder.GetEdmModels() );
+                } );
             app.UseSwagger();
             app.UseSwaggerUI(
                 options =>

--- a/samples/webapi/SwaggerODataWebApiSample/Startup.cs
+++ b/samples/webapi/SwaggerODataWebApiSample/Startup.cs
@@ -5,10 +5,8 @@ namespace Microsoft.Examples
     using global::Owin;
     using Microsoft.AspNet.OData;
     using Microsoft.AspNet.OData.Builder;
-    using Microsoft.AspNet.OData.Query;
     using Microsoft.AspNet.OData.Routing;
     using Microsoft.Examples.Configuration;
-    using Microsoft.Examples.Models;
     using Microsoft.OData;
     using Microsoft.OData.UriParser;
     using Newtonsoft.Json.Serialization;
@@ -87,38 +85,38 @@ namespace Microsoft.Examples
                 } );
 
             configuration.EnableSwagger(
-                           "{apiVersion}/swagger",
-                           swagger =>
-                           {
-                               // build a swagger document and endpoint for each discovered API version
-                               swagger.MultipleApiVersions(
-                                  ( apiDescription, version ) => apiDescription.GetGroupName() == version,
-                                  info =>
-                                  {
-                                      foreach ( var group in apiExplorer.ApiDescriptions )
-                                      {
-                                          var description = "A sample application with Swagger, Swashbuckle, OData, and API versioning.";
+                "{apiVersion}/swagger",
+                swagger =>
+                {
+                    // build a swagger document and endpoint for each discovered API version
+                    swagger.MultipleApiVersions(
+                        ( apiDescription, version ) => apiDescription.GetGroupName() == version,
+                        info =>
+                        {
+                            foreach ( var group in apiExplorer.ApiDescriptions )
+                            {
+                                var description = "A sample application with Swagger, Swashbuckle, OData, and API versioning.";
 
-                                          if ( group.IsDeprecated )
-                                          {
-                                              description += " This API version has been deprecated.";
-                                          }
+                                if ( group.IsDeprecated )
+                                {
+                                    description += " This API version has been deprecated.";
+                                }
 
-                                          info.Version( group.Name, $"Sample API {group.ApiVersion}" )
-                                              .Contact( c => c.Name( "Bill Mei" ).Email( "bill.mei@somewhere.com" ) )
-                                              .Description( description )
-                                              .License( l => l.Name( "MIT" ).Url( "https://opensource.org/licenses/MIT" ) )
-                                              .TermsOfService( "Shareware" );
-                                      }
-                                  } );
+                                info.Version( group.Name, $"Sample API {group.ApiVersion}" )
+                                    .Contact( c => c.Name( "Bill Mei" ).Email( "bill.mei@somewhere.com" ) )
+                                    .Description( description )
+                                    .License( l => l.Name( "MIT" ).Url( "https://opensource.org/licenses/MIT" ) )
+                                    .TermsOfService( "Shareware" );
+                            }
+                        } );
 
-                               // add a custom operation filter which documents the implicit API version parameter
-                               swagger.OperationFilter<SwaggerDefaultValues>();
+                    // add a custom operation filter which documents the implicit API version parameter
+                    swagger.OperationFilter<SwaggerDefaultValues>();
 
-                               // integrate xml comments
-                               swagger.IncludeXmlComments( XmlCommentsFilePath );
-                           } )
-                        .EnableSwaggerUi( swagger => swagger.EnableDiscoveryUrlSelector() );
+                    // integrate xml comments
+                    swagger.IncludeXmlComments( XmlCommentsFilePath );
+                } )
+                .EnableSwaggerUi( swagger => swagger.EnableDiscoveryUrlSelector() );
 
             builder.UseWebApi( httpServer );
         }

--- a/samples/webapi/SwaggerWebApiSample/Startup.cs
+++ b/samples/webapi/SwaggerWebApiSample/Startup.cs
@@ -45,38 +45,38 @@ namespace Microsoft.Examples
                 } );
 
             configuration.EnableSwagger(
-                            "{apiVersion}/swagger",
-                            swagger =>
+                "{apiVersion}/swagger",
+                swagger =>
+                {
+                    // build a swagger document and endpoint for each discovered API version
+                    swagger.MultipleApiVersions(
+                        ( apiDescription, version ) => apiDescription.GetGroupName() == version,
+                        info =>
+                        {
+                            foreach ( var group in apiExplorer.ApiDescriptions )
                             {
-                                // build a swagger document and endpoint for each discovered API version
-                                swagger.MultipleApiVersions(
-                                    ( apiDescription, version ) => apiDescription.GetGroupName() == version,
-                                    info =>
-                                    {
-                                        foreach ( var group in apiExplorer.ApiDescriptions )
-                                        {
-                                            var description = "A sample application with Swagger, Swashbuckle, and API versioning.";
+                                var description = "A sample application with Swagger, Swashbuckle, and API versioning.";
 
-                                            if ( group.IsDeprecated )
-                                            {
-                                                description += " This API version has been deprecated.";
-                                            }
+                                if ( group.IsDeprecated )
+                                {
+                                    description += " This API version has been deprecated.";
+                                }
 
-                                            info.Version( group.Name, $"Sample API {group.ApiVersion}" )
-                                                .Contact( c => c.Name( "Bill Mei" ).Email( "bill.mei@somewhere.com" ) )
-                                                .Description( description )
-                                                .License( l => l.Name( "MIT" ).Url( "https://opensource.org/licenses/MIT" ) )
-                                                .TermsOfService( "Shareware" );
-                                        }
-                                    } );
+                                info.Version( group.Name, $"Sample API {group.ApiVersion}" )
+                                    .Contact( c => c.Name( "Bill Mei" ).Email( "bill.mei@somewhere.com" ) )
+                                    .Description( description )
+                                    .License( l => l.Name( "MIT" ).Url( "https://opensource.org/licenses/MIT" ) )
+                                    .TermsOfService( "Shareware" );
+                            }
+                        } );
                                 
-                                // add a custom operation filter which sets default values
-                                swagger.OperationFilter<SwaggerDefaultValues>();
+                    // add a custom operation filter which sets default values
+                    swagger.OperationFilter<SwaggerDefaultValues>();
 
-                                // integrate xml comments
-                                swagger.IncludeXmlComments( XmlCommentsFilePath );
-                            } )
-                         .EnableSwaggerUi( swagger => swagger.EnableDiscoveryUrlSelector() );
+                    // integrate xml comments
+                    swagger.IncludeXmlComments( XmlCommentsFilePath );
+                } )
+                .EnableSwaggerUi( swagger => swagger.EnableDiscoveryUrlSelector() );
 
             builder.UseWebApi( httpServer );
         }

--- a/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Common.OData.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -23,6 +23,7 @@
     using System.Web.Http.Dispatcher;
     using ControllerActionDescriptor = System.Web.Http.Controllers.HttpActionDescriptor;
 #endif
+    using static Microsoft.OData.ODataUrlKeyDelimiter;
     using static ODataRouteTemplateGenerationKind;
 
     sealed partial class ODataRouteBuilderContext
@@ -99,5 +100,9 @@
 
             return ODataRouteActionType.Unknown;
         }
+
+        // Slash became the default 4/18/2018
+        // REF: https://github.com/OData/WebApi/pull/1393
+        static ODataUrlKeyDelimiter UrlKeyDelimiterOrDefault( ODataUrlKeyDelimiter urlKeyDelimiter ) => urlKeyDelimiter ?? Slash;
     }
 }

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -12,7 +12,6 @@
     using System.Web.Http;
     using System.Web.Http.Controllers;
     using System.Web.Http.Description;
-    using static Microsoft.OData.ODataUrlKeyDelimiter;
     using static System.Linq.Enumerable;
 
     partial class ODataRouteBuilderContext
@@ -43,7 +42,7 @@
             ActionDescriptor = actionDescriptor;
             ParameterDescriptions = parameterDescriptions;
             Options = options;
-            UrlKeyDelimiter = configuration.GetUrlKeyDelimiter() ?? Parentheses;
+            UrlKeyDelimiter = UrlKeyDelimiterOrDefault( configuration.GetUrlKeyDelimiter() );
 
             var container = EdmModel.EntityContainer;
 

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/Microsoft.AspNet.OData.Versioning.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.1.1</VersionPrefix>
+  <VersionPrefix>3.1.2</VersionPrefix>
   <AssemblyVersion>3.1.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Web API Versioned API Explorer for OData v4.0</AssemblyTitle>

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/ReleaseNotes.txt
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/ReleaseNotes.txt
@@ -1,4 +1,1 @@
-﻿Support array URL syntax for collection parameters (#496)
-Support DataMemberAttribute (#511)
-Support inherited ODataValue<T> (#513)
-Preserve attributes during model substitution (#520)
+﻿Fix key as segment route template generation (#526)

--- a/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/System.Web.Http/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Versioning.ApiExplorer/System.Web.Http/HttpConfigurationExtensions.cs
@@ -2,7 +2,6 @@
 {
     using Microsoft;
     using Microsoft.OData;
-    using Microsoft.Web.Http;
     using Microsoft.Web.Http.Description;
     using System.Collections.Concurrent;
     using System.Diagnostics.Contracts;
@@ -70,12 +69,12 @@
         {
             Contract.Requires( configuration != null );
 
-            if ( configuration.Properties.TryGetValue( UrlKeyDelimiterKey, out var value ) && value is ODataUrlKeyDelimiter delimiter )
+            if ( configuration.Properties.TryGetValue( UrlKeyDelimiterKey, out var value ) )
             {
-                return delimiter;
+                return value as ODataUrlKeyDelimiter;
             }
 
-            return ODataUrlKeyDelimiter.Parentheses;
+            return default;
         }
     }
 }

--- a/src/Microsoft.AspNet.OData.Versioning/Microsoft.AspNet.OData.Versioning.csproj
+++ b/src/Microsoft.AspNet.OData.Versioning/Microsoft.AspNet.OData.Versioning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.0.1</VersionPrefix>
+  <VersionPrefix>3.0.2</VersionPrefix>
   <AssemblyVersion>3.0.0.0</AssemblyVersion>
   <TargetFramework>net45</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Web API Versioning for OData v4.0</AssemblyTitle>

--- a/src/Microsoft.AspNet.OData.Versioning/ReleaseNotes.txt
+++ b/src/Microsoft.AspNet.OData.Versioning/ReleaseNotes.txt
@@ -1,5 +1,2 @@
-﻿Generate navigation property templates by convention (#463)
-Fix selecting the assumed, default API version (#471)
-Fix overriding global query settings (#488)
-Add appropriate separators for composite keys (#500)
-Fix client vs server route template generation (#502)
+﻿Fix container builder regression in OData 7.2+ (#525)
+Fix key as segment route template generation (#526)

--- a/src/Microsoft.AspNet.OData.Versioning/System.Web.Http/IContainerBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.OData.Versioning/System.Web.Http/IContainerBuilderExtensions.cs
@@ -1,93 +1,28 @@
 ﻿namespace System.Web.Http
 {
-    using Microsoft.AspNet.OData;
-    using Microsoft.AspNet.OData.Formatter.Deserialization;
-    using Microsoft.AspNet.OData.Formatter.Serialization;
-    using Microsoft.AspNet.OData.Query;
-    using Microsoft.AspNet.OData.Query.Expressions;
-    using Microsoft.AspNet.OData.Query.Validators;
-    using Microsoft.AspNet.OData.Routing;
     using Microsoft.AspNet.OData.Routing.Conventions;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.OData;
-    using static Microsoft.OData.ServiceLifetime;
+    using System.Reflection;
+    using static System.Linq.Expressions.Expression;
 
     static class IContainerBuilderExtensions
     {
+        private static readonly Lazy<Action<IContainerBuilder>> addDefaultWebApiServices = new Lazy<Action<IContainerBuilder>>( NewAddDefaultWebApiServicesFunc );
+
         internal static void InitializeAttributeRouting( this IServiceProvider serviceProvider ) => serviceProvider.GetServices<IODataRoutingConvention>();
 
-        internal static void AddDefaultWebApiServices( this IContainerBuilder builder )
-        {
-            builder.AddService<IODataPathHandler, DefaultODataPathHandler>( Singleton );
-            AddServicePrototypes( builder );
-            AddQueryValidators( builder );
-            AddSerializationProviders( builder );
-            AddDeserializerServices( builder );
-            AddSerializerServices( builder );
-            AddBinders( builder );
-            AddHttpRequestScope( builder );
-        }
+        internal static void AddDefaultWebApiServices( this IContainerBuilder builder ) => addDefaultWebApiServices.Value( builder );
 
-        static void AddServicePrototypes( IContainerBuilder builder )
+        static Action<IContainerBuilder> NewAddDefaultWebApiServicesFunc()
         {
-            builder.AddServicePrototype( new ODataMessageReaderSettings() { EnableMessageStreamDisposal = false, MessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = long.MaxValue } } );
-            builder.AddServicePrototype( new ODataMessageWriterSettings() { EnableMessageStreamDisposal = false, MessageQuotas = new ODataMessageQuotas { MaxReceivedMessageSize = long.MaxValue } } );
-        }
+            var type = Type.GetType( "Microsoft.AspNet.OData.Extensions.ContainerBuilderExtensions, Microsoft.AspNet.OData", throwOnError: true );
+            var method = type.GetRuntimeMethod( nameof( AddDefaultWebApiServices ), new[] { typeof( IContainerBuilder ) } );
+            var builder = Parameter( typeof( IContainerBuilder ), "builder" );
+            var body = Call( null, method, builder );
+            var lambda = Lambda<Action<IContainerBuilder>>( body, builder );
 
-        static void AddQueryValidators( IContainerBuilder builder )
-        {
-            builder.AddService<CountQueryValidator>( Singleton );
-            builder.AddService<FilterQueryValidator>( Scoped );
-            builder.AddService<ODataQueryValidator>( Singleton );
-            builder.AddService<OrderByQueryValidator>( Singleton );
-            builder.AddService<SelectExpandQueryValidator>( Singleton );
-            builder.AddService<SkipQueryValidator>( Singleton );
-            builder.AddService<TopQueryValidator>( Singleton );
-        }
-
-        static void AddSerializationProviders( IContainerBuilder builder )
-        {
-            builder.AddService<ODataSerializerProvider, DefaultODataSerializerProvider>( Singleton );
-            builder.AddService<ODataDeserializerProvider, DefaultODataDeserializerProvider>( Singleton );
-        }
-
-        static void AddDeserializerServices( IContainerBuilder builder )
-        {
-            builder.AddService<ODataResourceDeserializer>( Singleton );
-            builder.AddService<ODataEnumDeserializer>( Singleton );
-            builder.AddService<ODataPrimitiveDeserializer>( Singleton );
-            builder.AddService<ODataResourceSetDeserializer>( Singleton );
-            builder.AddService<ODataCollectionDeserializer>( Singleton );
-            builder.AddService<ODataEntityReferenceLinkDeserializer>( Singleton );
-            builder.AddService<ODataActionPayloadDeserializer>( Singleton );
-        }
-
-        static void AddSerializerServices( IContainerBuilder builder )
-        {
-            builder.AddService<ODataEnumSerializer>( Singleton );
-            builder.AddService<ODataPrimitiveSerializer>( Singleton );
-            builder.AddService<ODataDeltaFeedSerializer>( Singleton );
-            builder.AddService<ODataResourceSetSerializer>( Singleton );
-            builder.AddService<ODataCollectionSerializer>( Singleton );
-            builder.AddService<ODataResourceSerializer>( Singleton );
-            builder.AddService<ODataServiceDocumentSerializer>( Singleton );
-            builder.AddService<ODataEntityReferenceLinkSerializer>( Singleton );
-            builder.AddService<ODataEntityReferenceLinksSerializer>( Singleton );
-            builder.AddService<ODataErrorSerializer>( Singleton );
-            builder.AddService<ODataMetadataSerializer>( Singleton );
-            builder.AddService<ODataRawValueSerializer>( Singleton );
-        }
-
-        static void AddBinders( IContainerBuilder builder )
-        {
-            builder.AddService<ODataQuerySettings>( Scoped );
-            builder.AddService<FilterBinder>( Transient );
-        }
-
-        static void AddHttpRequestScope( IContainerBuilder builder )
-        {
-            builder.AddService<HttpRequestScope>( Scoped );
-            builder.AddService( Scoped, sp => sp.GetRequiredService<HttpRequestScope>().HttpRequest );
+            return lambda.Compile();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/AspNet.OData/Routing/ODataRouteBuilderContext.cs
@@ -10,7 +10,6 @@
     using System.Collections.Generic;
     using System.Diagnostics.Contracts;
     using System.Reflection;
-    using static Microsoft.OData.ODataUrlKeyDelimiter;
     using static System.Linq.Enumerable;
 
     partial class ODataRouteBuilderContext
@@ -35,7 +34,7 @@
             ActionDescriptor = actionDescriptor;
             ParameterDescriptions = new List<ApiParameterDescription>();
             Options = options;
-            UrlKeyDelimiter = serviceProvider.GetRequiredService<ODataOptions>().UrlKeyDelimiter ?? Parentheses;
+            UrlKeyDelimiter = UrlKeyDelimiterOrDefault( serviceProvider.GetRequiredService<ODataOptions>().UrlKeyDelimiter );
 
             var container = EdmModel.EntityContainer;
 

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.csproj
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.2.1</VersionPrefix>
+  <VersionPrefix>3.2.2</VersionPrefix>
   <AssemblyVersion>3.2.0.0</AssemblyVersion>
   <TargetFramework>netstandard2.0</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Core Versioned API Explorer for OData v4.0</AssemblyTitle>

--- a/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/ReleaseNotes.txt
+++ b/src/Microsoft.AspNetCore.OData.Versioning.ApiExplorer/ReleaseNotes.txt
@@ -1,5 +1,1 @@
-﻿Support array URL syntax for collection parameters (#496)
-Support DataMemberAttribute (#511)
-Support inherited ODataValue<T> (#513)
-Ensure implicitly versioned ActionModel has associated ControllerModel (#519)
-Preserve attributes during model substitution (#520)
+﻿Fix key as segment route template generation (#526)

--- a/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBuilderContext.Core.cs
+++ b/src/Microsoft.AspNetCore.OData.Versioning/AspNet.OData/Routing/ODataRouteBuilderContext.Core.cs
@@ -9,7 +9,6 @@
     using System;
     using System.Diagnostics.Contracts;
     using System.Reflection;
-    using static Microsoft.OData.ODataUrlKeyDelimiter;
     using static System.Linq.Enumerable;
 
     partial class ODataRouteBuilderContext
@@ -33,7 +32,7 @@
             Route = routeMapping.Route;
             ActionDescriptor = actionDescriptor;
             Options = options;
-            UrlKeyDelimiter = serviceProvider.GetRequiredService<ODataOptions>().UrlKeyDelimiter ?? Parentheses;
+            UrlKeyDelimiter = UrlKeyDelimiterOrDefault( serviceProvider.GetRequiredService<ODataOptions>().UrlKeyDelimiter );
 
             var container = EdmModel.EntityContainer;
 

--- a/src/Microsoft.AspNetCore.OData.Versioning/Microsoft.AspNetCore.OData.Versioning.csproj
+++ b/src/Microsoft.AspNetCore.OData.Versioning/Microsoft.AspNetCore.OData.Versioning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup>
-  <VersionPrefix>3.2.1</VersionPrefix>
+  <VersionPrefix>3.2.2</VersionPrefix>
   <AssemblyVersion>3.2.0.0</AssemblyVersion>
   <TargetFramework>netstandard2.0</TargetFramework>
   <AssemblyTitle>Microsoft ASP.NET Core API Versioning for OData v4.0</AssemblyTitle>

--- a/src/Microsoft.AspNetCore.OData.Versioning/ReleaseNotes.txt
+++ b/src/Microsoft.AspNetCore.OData.Versioning/ReleaseNotes.txt
@@ -1,1 +1,1 @@
-﻿Ensure implicitly versioned ActionModel has associated ControllerModel (#519)
+﻿Fix key as segment route template generation (#526)

--- a/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNetCore.Mvc.ApiExplorer/ODataApiDescriptionProviderTest.cs
+++ b/test/Microsoft.AspNetCore.OData.Versioning.ApiExplorer.Tests/AspNetCore.Mvc.ApiExplorer/ODataApiDescriptionProviderTest.cs
@@ -58,7 +58,7 @@
                 {
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/GetSalesTaxRate(PostalCode={postalCode})" },
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/Orders({key})" },
-                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People({key})" },
+                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People/{key}" },
                 },
                 options => options.ExcludingMissingMembers() );
         }
@@ -75,7 +75,7 @@
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/Orders({key})" },
                     new { HttpMethod = "POST", GroupName, RelativePath = "api/Orders" },
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/Orders/MostExpensive" },
-                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People({key})" },
+                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People/{key}" },
                 },
                 options => options.ExcludingMissingMembers() );
         }
@@ -96,7 +96,7 @@
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/Orders/MostExpensive" },
                     new { HttpMethod = "POST", GroupName, RelativePath = "api/Orders({key})/Rate" },
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/People" },
-                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People({key})" },
+                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People/{key}" },
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/People/NewHires(Since={since})" },
               },
               options => options.ExcludingMissingMembers() );
@@ -121,10 +121,10 @@
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/Orders/MostExpensive" },
                     new { HttpMethod = "POST", GroupName, RelativePath = "api/Orders({key})/Rate" },
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/People" },
-                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People({key})" },
+                    new { HttpMethod = "GET", GroupName, RelativePath = "api/People/{key}" },
                     new { HttpMethod = "POST", GroupName, RelativePath = "api/People" },
                     new { HttpMethod = "GET", GroupName, RelativePath = "api/People/NewHires(Since={since})" },
-                    new { HttpMethod = "POST", GroupName, RelativePath = "api/People({key})/Promote" },
+                    new { HttpMethod = "POST", GroupName, RelativePath = "api/People/{key}/Promote" },
                 },
                 options => options.ExcludingMissingMembers() );
         }

--- a/test/directory.build.props
+++ b/test/directory.build.props
@@ -14,16 +14,15 @@
  </ItemGroup>
 
  <ItemGroup Condition=" '$(MSBuildProjectExtension)' != '.shproj' ">
-  <PackageReference Include="FluentAssertions" Version="5.5.3" />
-  <PackageReference Include="Moq" Version="4.10.1" />
+  <PackageReference Include="FluentAssertions" Version="5.7.0" />
+  <PackageReference Include="Moq" Version="4.12.0" />
   <PackageReference Include="xunit" Version="2.4.1" />
   <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
  </ItemGroup>
 
  <ItemGroup Condition=" '$(IsAspNetCore)' == 'true' ">
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-  <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
  </ItemGroup>
-
 
 </Project>


### PR DESCRIPTION
Summary of fixes:

- Fix regression in OData 7.2 when registering default services; requires Reflection once again
- Fix _key as segment_ URL generation
- Update default key delimiter to match OData default, which is now slash
- Update sample projects