### PR TITLE
Add properties reordering feature to the swagger generated OData models

### DIFF
--- a/samples/aspnetcore/SwaggerODataSample/Models/Address.cs
+++ b/samples/aspnetcore/SwaggerODataSample/Models/Address.cs
@@ -18,7 +18,7 @@
         /// Gets or sets the street address.
         /// </summary>
         /// <value>The street address.</value>
-        [DataMember]
+        [DataMember( Order = 0 )]
         public string Street { get; set; }
 
         /// <summary>
@@ -29,17 +29,17 @@
         public string City { get; set; }
 
         /// <summary>
+        /// Gets or sets the address zip code.
+        /// </summary>
+        /// <value>The address zip code.</value>
+        [DataMember( Name = "zip", Order = 1 )]
+        public string ZipCode { get; set; }
+        /// <summary>
         /// Gets or sets the address state.
         /// </summary>
         /// <value>The address state.</value>
         [DataMember]
         public string State { get; set; }
 
-        /// <summary>
-        /// Gets or sets the address zip code.
-        /// </summary>
-        /// <value>The address zip code.</value>
-        [DataMember(Name = "zip")]
-        public string ZipCode { get; set; }
     }
 }

--- a/samples/aspnetcore/SwaggerODataSample/PropertyReorderFilter.cs
+++ b/samples/aspnetcore/SwaggerODataSample/PropertyReorderFilter.cs
@@ -1,0 +1,59 @@
+namespace Microsoft.Examples
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
+
+    /// <summary>
+    /// Reorders schema properties according to DataMember.Order attribute
+    /// </summary>
+    public class PropertyReorderFilter : ISchemaFilter
+    {
+        /// <inheritdoc />
+        public void Apply( Schema schema, SchemaFilterContext context )
+        {
+            if ( schema.Properties == null
+                 || context.SystemType == null
+                 || context.SystemType.GetCustomAttribute<DataContractAttribute>() == null ) return;
+
+            schema.Properties = ReorderProperties( schema.Properties,
+                context.SystemType.GetProperties().ExtractAttributes() );
+        }
+
+        private static IDictionary<string, Schema> ReorderProperties( IDictionary<string, Schema> properties, IEnumerable<PropertyOrder> clrProps )
+        {
+            return properties
+                .Join( clrProps, pair => pair.Key, info => info.Name, ( pair, info ) => new
+                {
+                    pair.Key,
+                    info.Order,
+                    pair.Value
+                } )
+                .OrderBy( p => p.Order )
+                .ToDictionary( arg => arg.Key, arg => arg.Value );
+        }
+    }
+
+    internal static class OrderExtension
+    {
+        internal static IEnumerable<PropertyOrder> ExtractAttributes( this IEnumerable<PropertyInfo> props )
+        {
+            return props
+                .Select( p => new { p, attr = p.GetCustomAttribute<DataMemberAttribute>() } )
+                .Select( _ => new PropertyOrder
+                {
+                    Name = _.attr != null && _.attr.IsNameSetExplicitly ? _.attr.Name : _.p.Name.ToLowerInvariant(),
+                    Order = _.attr != null ? _.attr.Order < 0 ? int.MaxValue : _.attr.Order : _.p.MetadataToken
+                } );
+        }
+    }
+
+    internal class PropertyOrder
+    {
+        public string Name { get; set; }
+        public int Order { get; set; }
+    }
+}

--- a/samples/aspnetcore/SwaggerODataSample/Startup.cs
+++ b/samples/aspnetcore/SwaggerODataSample/Startup.cs
@@ -63,6 +63,9 @@
                     // add a custom operation filter which sets default values
                     options.OperationFilter<SwaggerDefaultValues>();
 
+                    // reordering properties in swagger documentation according to the DataMember attribute (if defined)
+                    options.SchemaFilter<PropertyReorderFilter>();
+
                     // integrate xml comments
                     options.IncludeXmlComments( XmlCommentsFilePath );
                 } );

--- a/samples/aspnetcore/SwaggerODataSample/web.config
+++ b/samples/aspnetcore/SwaggerODataSample/web.config
@@ -1,14 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-
   <!--
     Configure your application settings in appsettings.json. Learn more at http://go.microsoft.com/fwlink/?LinkId=786380
   -->
-
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" hostingModel="InProcess">
+      <environmentVariables>
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
+        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      </environmentVariables>
+    </aspNetCore>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
This PR adds example of using Swashbuckle schema filter applied to the OData Asp.Net Core versioning sample in order to allow reordering of model properties using the `DataMemberAttribute`.
Usage: set the Order in [DataMember] with non-negative number to apply property sort order
```
    [DataContract]
    public class Address
    {
        /// <summary>
        /// Gets or sets the street address.
        /// </summary>
        /// <value>The street address.</value>
        [DataMember( Order = 0 )]
        public string Street { get; set; }

        /// <summary>
        /// Gets or sets the address city.
        /// </summary>
        /// <value>The address city.</value>
        [DataMember]
        public string City { get; set; }

        /// <summary>
        /// Gets or sets the address zip code.
        /// </summary>
        /// <value>The address zip code.</value>
        [DataMember( Name = "zip", Order = 1 )]
        public string ZipCode { get; set; }
    }
```
In the example above, property order in swagger doc will look like this:
**Address**
- street | _string_  Gets or sets the street address.
- zip | _string_  Gets or sets the address zip code.
- city | _string_  Gets or sets the address city.

> NOTE: the ZipCode property has been renamed as well as reordered. Non-reordered properties get initially defined order from source.
