### PR TITLE
Update Package Icon Url

### DIFF
--- a/build/nuget.props
+++ b/build/nuget.props
@@ -4,7 +4,7 @@
  <PropertyGroup Label="NuGet">
   <RepositoryType>git</RepositoryType>
   <RepositoryUrl>https://github.com/Microsoft/aspnet-api-versioning</RepositoryUrl>
-  <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
+  <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
   <PackageProjectUrl>https://github.com/Microsoft/aspnet-api-versioning/wiki</PackageProjectUrl>
   <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
### It is recommended to use the .net icon instead of the Microsoft icon

![image](https://user-images.githubusercontent.com/5714438/64695364-83237000-d4ce-11e9-919a-9645b5c72af9.png)

![https://go.microsoft.com/fwlink/?LinkID=288859](https://go.microsoft.com/fwlink/?LinkID=288859 "https://go.microsoft.com/fwlink/?LinkID=288859")

![http://go.microsoft.com/fwlink/?LinkID=288890](http://go.microsoft.com/fwlink/?LinkID=288890 "http://go.microsoft.com/fwlink/?LinkID=288890")