### PR TITLE
Improved performance of EnsureZeroOrOneApiVersions

### DIFF
--- a/src/Common/CollectionExtensions.cs
+++ b/src/Common/CollectionExtensions.cs
@@ -57,17 +57,23 @@ namespace Microsoft.AspNetCore.Mvc
             }
         }
 
-        internal static string EnsureZeroOrOneApiVersions( this ICollection<string> apiVersions )
+        internal static string? EnsureZeroOrOneApiVersions( this SortedSet<string>? apiVersions )
         {
-            if ( apiVersions.Count < 2 )
+            if ( apiVersions is null || apiVersions.Count == 0 )
             {
-                return apiVersions.SingleOrDefault();
+                return null;
             }
 
-            var requestedVersions = Join( ", ", apiVersions.OrderBy( v => v ) );
+            var requestedVersions = Join( ", ", apiVersions );
+
+            if ( apiVersions.Count == 1 )
+            {
+                return requestedVersions;
+            }
+
             var message = Format( InvariantCulture, SR.MultipleDifferentApiVersionsRequested, requestedVersions );
 
-            throw new AmbiguousApiVersionException( message, apiVersions.OrderBy( v => v ) );
+            throw new AmbiguousApiVersionException( message, apiVersions );
         }
 
         internal static void UnionWith<T>( this ICollection<T> collection, IEnumerable<T> other )

--- a/src/Common/Versioning/ApiVersionReader.cs
+++ b/src/Common/Versioning/ApiVersionReader.cs
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
 
             public string? Read( HttpRequest request )
             {
-                var versions = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+                SortedSet<string>? versions = null;
 
                 foreach ( var apiVersionReader in apiVersionReaders )
                 {
@@ -77,7 +77,8 @@ namespace Microsoft.AspNetCore.Mvc.Versioning
 
                     if ( !IsNullOrEmpty( version ) )
                     {
-                        versions.Add( version! );
+                        ( versions ?? new SortedSet<string>( StringComparer.OrdinalIgnoreCase ) )
+                            .Add( version! );
                     }
                 }
 

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/HeaderApiVersionReader.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/HeaderApiVersionReader.cs
@@ -25,13 +25,14 @@
             }
 
             var headers = request.Headers;
-            var versions = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+            SortedSet<string>? versions = null;
 
             foreach ( var name in HeaderNames )
             {
                 if ( headers.TryGetValues( name, out var values ) )
                 {
-                    versions.AddRange( values.Where( v => !IsNullOrEmpty( v ) ) );
+                    ( versions ?? new SortedSet<string>( StringComparer.OrdinalIgnoreCase ) )
+                        .AddRange( values.Where( v => !IsNullOrEmpty( v ) ) );
                 }
             }
 

--- a/src/Microsoft.AspNet.WebApi.Versioning/Versioning/QueryStringApiVersionReader.cs
+++ b/src/Microsoft.AspNet.WebApi.Versioning/Versioning/QueryStringApiVersionReader.cs
@@ -19,11 +19,19 @@
         /// <exception cref="AmbiguousApiVersionException">Multiple, different API versions were requested.</exception>
         public virtual string? Read( HttpRequestMessage request )
         {
-            var values = from pair in request.GetQueryNameValuePairs()
-                         from parameterName in ParameterNames
-                         where parameterName.Equals( pair.Key, OrdinalIgnoreCase ) && pair.Value.Length > 0
-                         select pair.Value;
-            var versions = new HashSet<string>( values, StringComparer.OrdinalIgnoreCase );
+            SortedSet<string>? versions = null;
+
+            foreach ( var pair in request.GetQueryNameValuePairs() )
+            {
+                foreach ( var parameterName in ParameterNames )
+                {
+                    if ( parameterName.Equals( pair.Key, OrdinalIgnoreCase ) && pair.Value.Length > 0 )
+                    {
+                        ( versions ?? new SortedSet<string>( StringComparer.OrdinalIgnoreCase ) )
+                            .Add( pair.Value );
+                    }
+                }
+            }
 
             return versions.EnsureZeroOrOneApiVersions();
         }

--- a/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/QueryStringApiVersionReader.cs
+++ b/src/Microsoft.AspNetCore.Mvc.Versioning/Versioning/QueryStringApiVersionReader.cs
@@ -24,7 +24,7 @@
                 throw new ArgumentNullException( nameof( request ) );
             }
 
-            var versions = new HashSet<string>( StringComparer.OrdinalIgnoreCase );
+            SortedSet<string>? versions = null;
 
             foreach ( var parameterName in ParameterNames )
             {
@@ -34,7 +34,8 @@
                 {
                     if ( !IsNullOrEmpty( value ) )
                     {
-                        versions.Add( value );
+                        ( versions ?? new SortedSet<string>( StringComparer.OrdinalIgnoreCase ) )
+                            .Add( value );
                     }
                 }
             }


### PR DESCRIPTION
Used a `SortedSet<string>` instantiated only when needed instead of a `HashSet<T>` unconditionally instantiated and twice sorted when used.

**Note:** unit tests were already failing